### PR TITLE
feat: Implement 9 remaining widgets for full Claude Code coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ echo '{"model":{"id":"claude-sonnet-4-5","display_name":"Sonnet"},"context_windo
 | `internal/status/` | StatusJSON input struct parsing (official Claude Code JSON schema) |
 | `internal/jsonl/` | JSONL transcript parsing (block-timer widget only) |
 | `internal/color/` | ANSI color codes, color names, color levels |
+| `internal/jsonl/` | JSONL transcript parsing (block-timer widget) |
 | `internal/git/` | Git branch, changes, worktree detection |
 | `internal/claude/` | Claude Code settings.json integration |
 | `internal/terminal/` | Terminal width detection |
@@ -78,7 +79,7 @@ type Widget interface {
 
 Widgets are registered in a map-based registry keyed by type string.
 
-### Available Widgets (27 registered, 32 planned)
+### Available Widgets (36 registered)
 
 Data source: (J) = from Claude Code JSON input, (G) = from git commands, (T) = from JSONL transcript, (S) = from system
 
@@ -100,7 +101,7 @@ Data source: (J) = from Claude Code JSON input, (G) = from git commands, (T) = f
 - **context-percentage** (J) - Context usage as percentage (from context_window.used_percentage)
 - **context-percentage-usable** (J) - Usable context percentage (80% of max)
 - **remaining-percentage** (J) - Remaining context window percentage (from context_window.remaining_percentage)
-- **block-timer** (T) - 5-hour session block timer (requires JSONL parsing)
+- **block-timer** (J/T) - 5-hour session block timer (from cost.total_duration_ms, JSONL fallback)
 - **session-clock** (J) - Session duration (from cost.total_duration_ms)
 - **session-cost** (J) - Session cost in USD (from cost.total_cost_usd)
 - **api-duration** (J) - API response time (from cost.total_api_duration_ms)

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -1,0 +1,37 @@
+package git
+
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// GetWorktree returns the worktree name if the current directory is a git worktree.
+// Returns empty string if in the main working tree or not in a git repository.
+func GetWorktree() string {
+	ctx, cancel := context.WithTimeout(context.Background(), gitTimeout)
+	defer cancel()
+
+	// Check if we are in a linked worktree.
+	// For linked worktrees, --git-dir returns something like:
+	//   /path/to/main/.git/worktrees/<name>
+	// For the main worktree, it returns:
+	//   /path/to/repo/.git
+	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--git-dir")
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+
+	gitDir := strings.TrimSpace(string(out))
+
+	// Check if this is a linked worktree by looking for /worktrees/ in the path.
+	dir, name := filepath.Split(gitDir)
+	dir = filepath.Clean(dir)
+	if filepath.Base(dir) == "worktrees" && name != "" {
+		return name
+	}
+
+	return ""
+}

--- a/internal/jsonl/reader.go
+++ b/internal/jsonl/reader.go
@@ -1,0 +1,51 @@
+// Package jsonl provides JSONL transcript file parsing for the block-timer widget.
+package jsonl
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"time"
+)
+
+// entry represents the minimal fields we need from a JSONL transcript entry.
+type entry struct {
+	Timestamp string `json:"timestamp"`
+}
+
+// GetSessionStart reads the first entry from a JSONL transcript file and returns
+// its timestamp. Returns zero time if the file cannot be read or parsed.
+func GetSessionStart(path string) time.Time {
+	if path == "" {
+		return time.Time{}
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return time.Time{}
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	if !scanner.Scan() {
+		return time.Time{}
+	}
+	line := scanner.Bytes()
+
+	var e entry
+	if unmarshalErr := json.Unmarshal(line, &e); unmarshalErr != nil {
+		return time.Time{}
+	}
+	if e.Timestamp == "" {
+		return time.Time{}
+	}
+
+	t, parseErr := time.Parse(time.RFC3339Nano, e.Timestamp)
+	if parseErr != nil {
+		// Try RFC3339 without nanoseconds.
+		t, parseErr = time.Parse(time.RFC3339, e.Timestamp)
+		if parseErr != nil {
+			return time.Time{}
+		}
+	}
+	return t
+}

--- a/internal/jsonl/reader_test.go
+++ b/internal/jsonl/reader_test.go
@@ -1,0 +1,104 @@
+package jsonl
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetSessionStart(t *testing.T) {
+	t.Run("valid RFC3339 timestamp", func(t *testing.T) {
+		f, err := os.CreateTemp("", "test-*.jsonl")
+		require.NoError(t, err)
+		defer os.Remove(f.Name())
+
+		_, err = f.WriteString(`{"timestamp":"2025-01-15T10:30:00Z","type":"start"}` + "\n")
+		require.NoError(t, err)
+		f.Close()
+
+		result := GetSessionStart(f.Name())
+		assert.Equal(t, 2025, result.Year())
+		assert.Equal(t, time.January, result.Month())
+		assert.Equal(t, 15, result.Day())
+		assert.Equal(t, 10, result.Hour())
+		assert.Equal(t, 30, result.Minute())
+	})
+
+	t.Run("valid RFC3339Nano timestamp", func(t *testing.T) {
+		f, err := os.CreateTemp("", "test-*.jsonl")
+		require.NoError(t, err)
+		defer os.Remove(f.Name())
+
+		_, err = f.WriteString(`{"timestamp":"2025-01-15T10:30:00.123456789Z","type":"start"}` + "\n")
+		require.NoError(t, err)
+		f.Close()
+
+		result := GetSessionStart(f.Name())
+		assert.False(t, result.IsZero())
+		assert.Equal(t, 10, result.Hour())
+	})
+
+	t.Run("multiple lines returns first", func(t *testing.T) {
+		f, err := os.CreateTemp("", "test-*.jsonl")
+		require.NoError(t, err)
+		defer os.Remove(f.Name())
+
+		_, err = f.WriteString(`{"timestamp":"2025-01-15T10:00:00Z"}` + "\n")
+		require.NoError(t, err)
+		_, err = f.WriteString(`{"timestamp":"2025-01-15T11:00:00Z"}` + "\n")
+		require.NoError(t, err)
+		f.Close()
+
+		result := GetSessionStart(f.Name())
+		assert.Equal(t, 10, result.Hour())
+	})
+
+	t.Run("empty file returns zero", func(t *testing.T) {
+		f, err := os.CreateTemp("", "test-*.jsonl")
+		require.NoError(t, err)
+		defer os.Remove(f.Name())
+		f.Close()
+
+		result := GetSessionStart(f.Name())
+		assert.True(t, result.IsZero())
+	})
+
+	t.Run("invalid JSON returns zero", func(t *testing.T) {
+		f, err := os.CreateTemp("", "test-*.jsonl")
+		require.NoError(t, err)
+		defer os.Remove(f.Name())
+
+		_, err = f.WriteString("{invalid}\n")
+		require.NoError(t, err)
+		f.Close()
+
+		result := GetSessionStart(f.Name())
+		assert.True(t, result.IsZero())
+	})
+
+	t.Run("missing timestamp field returns zero", func(t *testing.T) {
+		f, err := os.CreateTemp("", "test-*.jsonl")
+		require.NoError(t, err)
+		defer os.Remove(f.Name())
+
+		_, err = f.WriteString(`{"type":"start"}` + "\n")
+		require.NoError(t, err)
+		f.Close()
+
+		result := GetSessionStart(f.Name())
+		assert.True(t, result.IsZero())
+	})
+
+	t.Run("nonexistent file returns zero", func(t *testing.T) {
+		result := GetSessionStart("/nonexistent/path/transcript.jsonl")
+		assert.True(t, result.IsZero())
+	})
+
+	t.Run("empty path returns zero", func(t *testing.T) {
+		result := GetSessionStart("")
+		assert.True(t, result.IsZero())
+	})
+}

--- a/internal/widget/block_timer.go
+++ b/internal/widget/block_timer.go
@@ -1,0 +1,126 @@
+package widget
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/moond4rk/ccstatus/internal/config"
+	"github.com/moond4rk/ccstatus/internal/jsonl"
+)
+
+const (
+	blockDuration = 5 * time.Hour
+	barWidth      = 10
+)
+
+// BlockTimerWidget displays elapsed time within a 5-hour Claude Code session block.
+// Supports three display modes via metadata["display"]:
+//   - "time" (default): shows elapsed/total like "2h15m/5h"
+//   - "progress": shows progress bar "[=====>    ] 45%"
+//   - "percentage": shows just "45%"
+type BlockTimerWidget struct{}
+
+// Render returns the block timer display.
+// Uses cost.total_duration_ms when available, falls back to JSONL transcript parsing.
+func (w *BlockTimerWidget) Render(item *config.WidgetItem, ctx RenderContext, _ *config.Settings) string {
+	elapsed := w.getElapsed(ctx)
+	if elapsed <= 0 {
+		return ""
+	}
+
+	// Clamp to block duration.
+	if elapsed > blockDuration {
+		elapsed = blockDuration
+	}
+
+	mode := "time"
+	if item.Metadata != nil {
+		if m, ok := item.Metadata["display"]; ok {
+			mode = m
+		}
+	}
+
+	pct := float64(elapsed) / float64(blockDuration) * 100
+
+	switch mode {
+	case "progress":
+		return formatProgressBar(pct)
+	case "percentage":
+		return fmt.Sprintf("%.0f%%", pct)
+	default:
+		return formatBlockTime(elapsed)
+	}
+}
+
+// getElapsed determines session elapsed time.
+// Prefers cost.total_duration_ms; falls back to JSONL transcript timestamp.
+func (w *BlockTimerWidget) getElapsed(ctx RenderContext) time.Duration {
+	if ctx.Data == nil {
+		return 0
+	}
+
+	// Primary: use cost.total_duration_ms if available.
+	if ctx.Data.Cost != nil && ctx.Data.Cost.TotalDurationMS != nil {
+		ms := *ctx.Data.Cost.TotalDurationMS
+		if ms > 0 {
+			return time.Duration(ms) * time.Millisecond
+		}
+	}
+
+	// Fallback: parse JSONL transcript for session start time.
+	if ctx.Data.TranscriptPath != "" {
+		start := jsonl.GetSessionStart(ctx.Data.TranscriptPath)
+		if !start.IsZero() {
+			return time.Since(start)
+		}
+	}
+
+	return 0
+}
+
+func formatBlockTime(elapsed time.Duration) string {
+	hours := int(elapsed.Hours())
+	mins := int(elapsed.Minutes()) % 60
+	if hours == 0 && mins == 0 {
+		return "<1m/5h"
+	}
+	if hours == 0 {
+		return fmt.Sprintf("%dm/5h", mins)
+	}
+	if mins == 0 {
+		return fmt.Sprintf("%dh/5h", hours)
+	}
+	return fmt.Sprintf("%dh%dm/5h", hours, mins)
+}
+
+func formatProgressBar(pct float64) string {
+	filled := min(int(pct*barWidth/100), barWidth)
+	empty := barWidth - filled
+	var b strings.Builder
+	b.WriteByte('[')
+	for range filled {
+		b.WriteByte('=')
+	}
+	if empty > 0 {
+		b.WriteByte('>')
+		for range empty - 1 {
+			b.WriteByte(' ')
+		}
+	}
+	b.WriteByte(']')
+	fmt.Fprintf(&b, " %.0f%%", pct)
+	return b.String()
+}
+
+// DefaultColor returns the default foreground color.
+func (w *BlockTimerWidget) DefaultColor() string { return defaultDimColor }
+
+// DisplayName returns the human-readable name.
+func (w *BlockTimerWidget) DisplayName() string { return "Block Timer" }
+
+// Description returns what this widget shows.
+func (w *BlockTimerWidget) Description() string { return "5-hour session block timer" }
+
+// SupportsRawValue returns false since display mode is controlled by metadata.
+func (w *BlockTimerWidget) SupportsRawValue() bool { return false }

--- a/internal/widget/custom_command.go
+++ b/internal/widget/custom_command.go
@@ -1,0 +1,102 @@
+package widget
+
+import (
+	"context"
+	"encoding/json"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/moond4rk/ccstatus/internal/config"
+)
+
+const defaultCommandTimeout = 3 * time.Second
+
+// CustomCommandWidget executes a shell command and displays its output.
+type CustomCommandWidget struct{}
+
+// Render executes the configured command and returns its first line of stdout.
+// The command receives the full JSON session data via stdin.
+func (w *CustomCommandWidget) Render(item *config.WidgetItem, ctx RenderContext, _ *config.Settings) string {
+	cmdPath := item.CommandPath
+	if cmdPath == "" {
+		return ""
+	}
+
+	timeout := defaultCommandTimeout
+	if item.Timeout > 0 {
+		timeout = time.Duration(item.Timeout) * time.Millisecond
+	}
+
+	cmdCtx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(cmdCtx, "sh", "-c", cmdPath)
+
+	// Pipe JSON data to stdin so the command can use it.
+	if ctx.Data != nil {
+		if data, err := json.Marshal(ctx.Data); err == nil {
+			cmd.Stdin = strings.NewReader(string(data))
+		}
+	}
+
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+
+	result := strings.TrimSpace(string(out))
+
+	// Take only the first line.
+	if idx := strings.IndexByte(result, '\n'); idx >= 0 {
+		result = result[:idx]
+	}
+
+	// Apply maxWidth truncation.
+	if item.MaxWidth > 0 && len(result) > item.MaxWidth {
+		result = result[:item.MaxWidth]
+	}
+
+	// Strip ANSI codes unless preserveColors is set.
+	if !item.PreserveColors {
+		result = stripANSI(result)
+	}
+
+	return result
+}
+
+// stripANSI removes ANSI escape sequences from a string.
+func stripANSI(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	i := 0
+	for i < len(s) {
+		if s[i] == '\x1b' && i+1 < len(s) && s[i+1] == '[' {
+			// Skip until we find the terminating letter.
+			j := i + 2
+			for j < len(s) && (s[j] < 'A' || s[j] > 'Z') && (s[j] < 'a' || s[j] > 'z') {
+				j++
+			}
+			if j < len(s) {
+				j++ // skip the terminating letter
+			}
+			i = j
+		} else {
+			b.WriteByte(s[i])
+			i++
+		}
+	}
+	return b.String()
+}
+
+// DefaultColor returns the default foreground color.
+func (w *CustomCommandWidget) DefaultColor() string { return "white" }
+
+// DisplayName returns the human-readable name.
+func (w *CustomCommandWidget) DisplayName() string { return "Custom Command" }
+
+// Description returns what this widget shows.
+func (w *CustomCommandWidget) Description() string { return "Output from a shell command" }
+
+// SupportsRawValue returns false since this widget has no compact mode.
+func (w *CustomCommandWidget) SupportsRawValue() bool { return false }

--- a/internal/widget/exceeds_200k.go
+++ b/internal/widget/exceeds_200k.go
@@ -1,0 +1,28 @@
+package widget
+
+import "github.com/moond4rk/ccstatus/internal/config"
+
+// Exceeds200KWidget displays a warning when token count exceeds the 200k threshold.
+type Exceeds200KWidget struct{}
+
+// Render returns ">200k" if the token count exceeds 200k, empty otherwise.
+func (w *Exceeds200KWidget) Render(_ *config.WidgetItem, ctx RenderContext, _ *config.Settings) string {
+	if ctx.Data == nil || ctx.Data.Exceeds200K == nil || !*ctx.Data.Exceeds200K {
+		return ""
+	}
+	return ">200k"
+}
+
+// DefaultColor returns the default foreground color.
+func (w *Exceeds200KWidget) DefaultColor() string { return "red" }
+
+// DisplayName returns the human-readable name.
+func (w *Exceeds200KWidget) DisplayName() string { return "Exceeds 200k" }
+
+// Description returns what this widget shows.
+func (w *Exceeds200KWidget) Description() string {
+	return "Warning when tokens exceed 200k threshold"
+}
+
+// SupportsRawValue returns false since this widget has no compact mode.
+func (w *Exceeds200KWidget) SupportsRawValue() bool { return false }

--- a/internal/widget/git_worktree.go
+++ b/internal/widget/git_worktree.go
@@ -1,0 +1,26 @@
+package widget
+
+import (
+	"github.com/moond4rk/ccstatus/internal/config"
+	"github.com/moond4rk/ccstatus/internal/git"
+)
+
+// GitWorktreeWidget displays the current git worktree name.
+type GitWorktreeWidget struct{}
+
+// Render returns the worktree name if in a linked worktree, empty otherwise.
+func (w *GitWorktreeWidget) Render(_ *config.WidgetItem, _ RenderContext, _ *config.Settings) string {
+	return git.GetWorktree()
+}
+
+// DefaultColor returns the default foreground color.
+func (w *GitWorktreeWidget) DefaultColor() string { return "magenta" }
+
+// DisplayName returns the human-readable name.
+func (w *GitWorktreeWidget) DisplayName() string { return "Git Worktree" }
+
+// Description returns what this widget shows.
+func (w *GitWorktreeWidget) Description() string { return "Current git worktree name" }
+
+// SupportsRawValue returns false since this widget has no compact mode.
+func (w *GitWorktreeWidget) SupportsRawValue() bool { return false }

--- a/internal/widget/session_id.go
+++ b/internal/widget/session_id.go
@@ -1,0 +1,36 @@
+package widget
+
+import "github.com/moond4rk/ccstatus/internal/config"
+
+const sessionIDShortLen = 8
+
+// SessionIDWidget displays the Claude Code session ID.
+type SessionIDWidget struct{}
+
+// Render returns the session ID. Normal mode truncates to 8 characters;
+// rawValue mode returns the full UUID.
+func (w *SessionIDWidget) Render(item *config.WidgetItem, ctx RenderContext, _ *config.Settings) string {
+	if ctx.Data == nil || ctx.Data.SessionID == "" {
+		return ""
+	}
+	if item.RawValue {
+		return ctx.Data.SessionID
+	}
+	id := ctx.Data.SessionID
+	if len(id) > sessionIDShortLen {
+		return id[:sessionIDShortLen]
+	}
+	return id
+}
+
+// DefaultColor returns the default foreground color.
+func (w *SessionIDWidget) DefaultColor() string { return defaultDimColor }
+
+// DisplayName returns the human-readable name.
+func (w *SessionIDWidget) DisplayName() string { return "Session ID" }
+
+// Description returns what this widget shows.
+func (w *SessionIDWidget) Description() string { return "Claude Code session identifier" }
+
+// SupportsRawValue returns true since this widget supports full UUID mode.
+func (w *SessionIDWidget) SupportsRawValue() bool { return true }

--- a/internal/widget/string_field.go
+++ b/internal/widget/string_field.go
@@ -1,0 +1,37 @@
+package widget
+
+import (
+	"github.com/moond4rk/ccstatus/internal/config"
+	"github.com/moond4rk/ccstatus/internal/status"
+)
+
+// stringFieldExtractor extracts a string value from StatusJSON.
+type stringFieldExtractor func(data *status.StatusJSON) string
+
+// stringFieldWidget is a generic widget that displays a single string field.
+type stringFieldWidget struct {
+	extract      stringFieldExtractor
+	defaultColor string
+	displayName  string
+	description  string
+}
+
+// Render returns the extracted string value, or empty if unavailable.
+func (w *stringFieldWidget) Render(_ *config.WidgetItem, ctx RenderContext, _ *config.Settings) string {
+	if ctx.Data == nil {
+		return ""
+	}
+	return w.extract(ctx.Data)
+}
+
+// DefaultColor returns the default foreground color.
+func (w *stringFieldWidget) DefaultColor() string { return w.defaultColor }
+
+// DisplayName returns the human-readable name.
+func (w *stringFieldWidget) DisplayName() string { return w.displayName }
+
+// Description returns what this widget shows.
+func (w *stringFieldWidget) Description() string { return w.description }
+
+// SupportsRawValue returns false since string field widgets have no compact mode.
+func (w *stringFieldWidget) SupportsRawValue() bool { return false }

--- a/internal/widget/terminal_width.go
+++ b/internal/widget/terminal_width.go
@@ -1,0 +1,30 @@
+package widget
+
+import (
+	"fmt"
+
+	"github.com/moond4rk/ccstatus/internal/config"
+)
+
+// TerminalWidthWidget displays the current terminal width in columns.
+type TerminalWidthWidget struct{}
+
+// Render returns the terminal width as a string.
+func (w *TerminalWidthWidget) Render(_ *config.WidgetItem, ctx RenderContext, _ *config.Settings) string {
+	if ctx.TerminalWidth <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("%d", ctx.TerminalWidth)
+}
+
+// DefaultColor returns the default foreground color.
+func (w *TerminalWidthWidget) DefaultColor() string { return defaultDimColor }
+
+// DisplayName returns the human-readable name.
+func (w *TerminalWidthWidget) DisplayName() string { return "Terminal Width" }
+
+// Description returns what this widget shows.
+func (w *TerminalWidthWidget) Description() string { return "Terminal width in columns" }
+
+// SupportsRawValue returns false since this widget has no compact mode.
+func (w *TerminalWidthWidget) SupportsRawValue() bool { return false }

--- a/internal/widget/widget.go
+++ b/internal/widget/widget.go
@@ -40,8 +40,9 @@ var registry = map[string]Widget{
 	"session-clock": &SessionClockWidget{},
 
 	// Git
-	"git-branch":  &GitBranchWidget{},
-	"git-changes": &GitChangesWidget{},
+	"git-branch":   &GitBranchWidget{},
+	"git-changes":  &GitChangesWidget{},
+	"git-worktree": &GitWorktreeWidget{},
 
 	// Token metrics
 	"tokens-input": &tokenWidget{
@@ -87,9 +88,49 @@ var registry = map[string]Widget{
 
 	// Cost and duration
 	"api-duration": &APIDurationWidget{},
+	"block-timer":  &BlockTimerWidget{},
+
+	// Session info
+	"session-id": &SessionIDWidget{},
+	"output-style": &stringFieldWidget{
+		extract: func(data *status.StatusJSON) string {
+			if data.OutputStyle == nil {
+				return ""
+			}
+			return data.OutputStyle.Name
+		},
+		defaultColor: defaultDimColor,
+		displayName:  "Output Style",
+		description:  "Current output style name",
+	},
+	"vim-mode": &stringFieldWidget{
+		extract: func(data *status.StatusJSON) string {
+			if data.Vim == nil {
+				return ""
+			}
+			return data.Vim.Mode
+		},
+		defaultColor: "yellow",
+		displayName:  "Vim Mode",
+		description:  "Current vim mode indicator",
+	},
+	"agent-name": &stringFieldWidget{
+		extract: func(data *status.StatusJSON) string {
+			if data.Agent == nil {
+				return ""
+			}
+			return data.Agent.Name
+		},
+		defaultColor: "cyan",
+		displayName:  "Agent Name",
+		description:  "Agent name when using --agent flag",
+	},
+	"exceeds-200k":   &Exceeds200KWidget{},
+	"terminal-width": &TerminalWidthWidget{},
 
 	// User-defined
-	"custom-text": &CustomTextWidget{},
+	"custom-text":    &CustomTextWidget{},
+	"custom-command": &CustomCommandWidget{},
 
 	// Layout
 	"separator":      &SeparatorWidget{},

--- a/internal/widget/widget_test.go
+++ b/internal/widget/widget_test.go
@@ -3,6 +3,7 @@ package widget
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -46,6 +47,15 @@ func TestGet(t *testing.T) {
 		{"current-usage-input", false},
 		{"current-usage-output", false},
 		{"cache-creation", false},
+		{"output-style", false},
+		{"session-id", false},
+		{"terminal-width", false},
+		{"vim-mode", false},
+		{"agent-name", false},
+		{"exceeds-200k", false},
+		{"custom-command", false},
+		{"git-worktree", false},
+		{"block-timer", false},
 		{"nonexistent", true},
 	}
 
@@ -613,6 +623,15 @@ func TestTypes(t *testing.T) {
 	assert.Contains(t, types, "current-usage-input")
 	assert.Contains(t, types, "current-usage-output")
 	assert.Contains(t, types, "cache-creation")
+	assert.Contains(t, types, "output-style")
+	assert.Contains(t, types, "session-id")
+	assert.Contains(t, types, "terminal-width")
+	assert.Contains(t, types, "vim-mode")
+	assert.Contains(t, types, "agent-name")
+	assert.Contains(t, types, "exceeds-200k")
+	assert.Contains(t, types, "custom-command")
+	assert.Contains(t, types, "git-worktree")
+	assert.Contains(t, types, "block-timer")
 }
 
 func TestRemainingPercentageWidget(t *testing.T) {
@@ -885,4 +904,377 @@ func TestRegister(t *testing.T) {
 	assert.Nil(t, Get("test-widget"))
 	Register("test-widget", &CustomTextWidget{})
 	assert.NotNil(t, Get("test-widget"))
+}
+
+func boolPtr(v bool) *bool { return &v }
+
+func TestOutputStyleWidget(t *testing.T) {
+	w := Get("output-style")
+	settings := config.DefaultSettings()
+
+	t.Run("returns style name", func(t *testing.T) {
+		item := config.WidgetItem{}
+		ctx := RenderContext{Data: &status.StatusJSON{
+			OutputStyle: &status.OutputStyle{Name: "text"},
+		}}
+		assert.Equal(t, "text", w.Render(&item, ctx, &settings))
+	})
+
+	t.Run("stream-json style", func(t *testing.T) {
+		item := config.WidgetItem{}
+		ctx := RenderContext{Data: &status.StatusJSON{
+			OutputStyle: &status.OutputStyle{Name: "stream-json"},
+		}}
+		assert.Equal(t, "stream-json", w.Render(&item, ctx, &settings))
+	})
+
+	t.Run("nil output style returns empty", func(t *testing.T) {
+		item := config.WidgetItem{}
+		ctx := RenderContext{Data: &status.StatusJSON{}}
+		assert.Empty(t, w.Render(&item, ctx, &settings))
+	})
+
+	t.Run("nil data returns empty", func(t *testing.T) {
+		item := config.WidgetItem{}
+		ctx := RenderContext{Data: nil}
+		assert.Empty(t, w.Render(&item, ctx, &settings))
+	})
+
+	assert.Equal(t, defaultDimColor, w.DefaultColor())
+	assert.False(t, w.SupportsRawValue())
+}
+
+func TestSessionIDWidget(t *testing.T) {
+	w := &SessionIDWidget{}
+	settings := config.DefaultSettings()
+
+	t.Run("truncated by default", func(t *testing.T) {
+		item := config.WidgetItem{}
+		ctx := RenderContext{Data: &status.StatusJSON{
+			SessionID: "abc12345-6789-0abc-def0-123456789abc",
+		}}
+		assert.Equal(t, "abc12345", w.Render(&item, ctx, &settings))
+	})
+
+	t.Run("raw value returns full UUID", func(t *testing.T) {
+		item := config.WidgetItem{RawValue: true}
+		ctx := RenderContext{Data: &status.StatusJSON{
+			SessionID: "abc12345-6789-0abc-def0-123456789abc",
+		}}
+		assert.Equal(t, "abc12345-6789-0abc-def0-123456789abc", w.Render(&item, ctx, &settings))
+	})
+
+	t.Run("short ID not truncated", func(t *testing.T) {
+		item := config.WidgetItem{}
+		ctx := RenderContext{Data: &status.StatusJSON{
+			SessionID: "abc",
+		}}
+		assert.Equal(t, "abc", w.Render(&item, ctx, &settings))
+	})
+
+	t.Run("empty session ID returns empty", func(t *testing.T) {
+		item := config.WidgetItem{}
+		ctx := RenderContext{Data: &status.StatusJSON{}}
+		assert.Empty(t, w.Render(&item, ctx, &settings))
+	})
+
+	t.Run("nil data returns empty", func(t *testing.T) {
+		item := config.WidgetItem{}
+		ctx := RenderContext{Data: nil}
+		assert.Empty(t, w.Render(&item, ctx, &settings))
+	})
+
+	assert.Equal(t, defaultDimColor, w.DefaultColor())
+	assert.True(t, w.SupportsRawValue())
+}
+
+func TestTerminalWidthWidget(t *testing.T) {
+	w := &TerminalWidthWidget{}
+	settings := config.DefaultSettings()
+	item := config.WidgetItem{}
+
+	t.Run("returns width as string", func(t *testing.T) {
+		ctx := RenderContext{TerminalWidth: 120}
+		assert.Equal(t, "120", w.Render(&item, ctx, &settings))
+	})
+
+	t.Run("zero width returns empty", func(t *testing.T) {
+		ctx := RenderContext{TerminalWidth: 0}
+		assert.Empty(t, w.Render(&item, ctx, &settings))
+	})
+
+	t.Run("negative width returns empty", func(t *testing.T) {
+		ctx := RenderContext{TerminalWidth: -1}
+		assert.Empty(t, w.Render(&item, ctx, &settings))
+	})
+
+	assert.Equal(t, defaultDimColor, w.DefaultColor())
+	assert.False(t, w.SupportsRawValue())
+}
+
+func TestVimModeWidget(t *testing.T) {
+	w := Get("vim-mode")
+	settings := config.DefaultSettings()
+	item := config.WidgetItem{}
+
+	t.Run("returns NORMAL mode", func(t *testing.T) {
+		ctx := RenderContext{Data: &status.StatusJSON{
+			Vim: &status.VimInfo{Mode: "NORMAL"},
+		}}
+		assert.Equal(t, "NORMAL", w.Render(&item, ctx, &settings))
+	})
+
+	t.Run("returns INSERT mode", func(t *testing.T) {
+		ctx := RenderContext{Data: &status.StatusJSON{
+			Vim: &status.VimInfo{Mode: "INSERT"},
+		}}
+		assert.Equal(t, "INSERT", w.Render(&item, ctx, &settings))
+	})
+
+	t.Run("nil vim returns empty", func(t *testing.T) {
+		ctx := RenderContext{Data: &status.StatusJSON{}}
+		assert.Empty(t, w.Render(&item, ctx, &settings))
+	})
+
+	t.Run("nil data returns empty", func(t *testing.T) {
+		ctx := RenderContext{Data: nil}
+		assert.Empty(t, w.Render(&item, ctx, &settings))
+	})
+
+	assert.Equal(t, "yellow", w.DefaultColor())
+	assert.False(t, w.SupportsRawValue())
+}
+
+func TestAgentNameWidget(t *testing.T) {
+	w := Get("agent-name")
+	settings := config.DefaultSettings()
+	item := config.WidgetItem{}
+
+	t.Run("returns agent name", func(t *testing.T) {
+		ctx := RenderContext{Data: &status.StatusJSON{
+			Agent: &status.AgentInfo{Name: "security-reviewer"},
+		}}
+		assert.Equal(t, "security-reviewer", w.Render(&item, ctx, &settings))
+	})
+
+	t.Run("nil agent returns empty", func(t *testing.T) {
+		ctx := RenderContext{Data: &status.StatusJSON{}}
+		assert.Empty(t, w.Render(&item, ctx, &settings))
+	})
+
+	t.Run("nil data returns empty", func(t *testing.T) {
+		ctx := RenderContext{Data: nil}
+		assert.Empty(t, w.Render(&item, ctx, &settings))
+	})
+
+	assert.Equal(t, "cyan", w.DefaultColor())
+	assert.False(t, w.SupportsRawValue())
+}
+
+func TestExceeds200KWidget(t *testing.T) {
+	w := &Exceeds200KWidget{}
+	settings := config.DefaultSettings()
+	item := config.WidgetItem{}
+
+	t.Run("true returns warning", func(t *testing.T) {
+		ctx := RenderContext{Data: &status.StatusJSON{
+			Exceeds200K: boolPtr(true),
+		}}
+		assert.Equal(t, ">200k", w.Render(&item, ctx, &settings))
+	})
+
+	t.Run("false returns empty", func(t *testing.T) {
+		ctx := RenderContext{Data: &status.StatusJSON{
+			Exceeds200K: boolPtr(false),
+		}}
+		assert.Empty(t, w.Render(&item, ctx, &settings))
+	})
+
+	t.Run("nil returns empty", func(t *testing.T) {
+		ctx := RenderContext{Data: &status.StatusJSON{}}
+		assert.Empty(t, w.Render(&item, ctx, &settings))
+	})
+
+	t.Run("nil data returns empty", func(t *testing.T) {
+		ctx := RenderContext{Data: nil}
+		assert.Empty(t, w.Render(&item, ctx, &settings))
+	})
+
+	assert.Equal(t, "red", w.DefaultColor())
+	assert.False(t, w.SupportsRawValue())
+}
+
+func TestCustomCommandWidget(t *testing.T) {
+	w := &CustomCommandWidget{}
+	settings := config.DefaultSettings()
+
+	t.Run("executes echo command", func(t *testing.T) {
+		item := config.WidgetItem{CommandPath: "echo hello"}
+		ctx := RenderContext{Data: &status.StatusJSON{}}
+		assert.Equal(t, "hello", w.Render(&item, ctx, &settings))
+	})
+
+	t.Run("takes first line only", func(t *testing.T) {
+		item := config.WidgetItem{CommandPath: "printf 'line1\nline2'"}
+		ctx := RenderContext{Data: &status.StatusJSON{}}
+		assert.Equal(t, "line1", w.Render(&item, ctx, &settings))
+	})
+
+	t.Run("applies maxWidth", func(t *testing.T) {
+		item := config.WidgetItem{CommandPath: "echo longstring", MaxWidth: 4}
+		ctx := RenderContext{Data: &status.StatusJSON{}}
+		assert.Equal(t, "long", w.Render(&item, ctx, &settings))
+	})
+
+	t.Run("strips ANSI by default", func(t *testing.T) {
+		item := config.WidgetItem{CommandPath: `printf '\033[32mgreen\033[0m'`}
+		ctx := RenderContext{Data: &status.StatusJSON{}}
+		assert.Equal(t, "green", w.Render(&item, ctx, &settings))
+	})
+
+	t.Run("preserves ANSI when configured", func(t *testing.T) {
+		item := config.WidgetItem{
+			CommandPath:    `printf '\033[32mgreen\033[0m'`,
+			PreserveColors: true,
+		}
+		ctx := RenderContext{Data: &status.StatusJSON{}}
+		assert.Contains(t, w.Render(&item, ctx, &settings), "green")
+	})
+
+	t.Run("empty commandPath returns empty", func(t *testing.T) {
+		item := config.WidgetItem{}
+		ctx := RenderContext{Data: &status.StatusJSON{}}
+		assert.Empty(t, w.Render(&item, ctx, &settings))
+	})
+
+	t.Run("failing command returns empty", func(t *testing.T) {
+		item := config.WidgetItem{CommandPath: "false"}
+		ctx := RenderContext{Data: &status.StatusJSON{}}
+		assert.Empty(t, w.Render(&item, ctx, &settings))
+	})
+
+	t.Run("pipes JSON to stdin", func(t *testing.T) {
+		item := config.WidgetItem{CommandPath: "cat | jq -r .version 2>/dev/null || echo fallback"}
+		ctx := RenderContext{Data: &status.StatusJSON{Version: "1.0.80"}}
+		result := w.Render(&item, ctx, &settings)
+		// jq may not be installed; accept either the parsed value or fallback.
+		assert.True(t, result == "1.0.80" || result == "fallback",
+			"expected '1.0.80' or 'fallback', got %q", result)
+	})
+
+	assert.Equal(t, "white", w.DefaultColor())
+	assert.False(t, w.SupportsRawValue())
+}
+
+func TestBlockTimerWidget(t *testing.T) {
+	w := &BlockTimerWidget{}
+	settings := config.DefaultSettings()
+
+	t.Run("time mode from duration_ms", func(t *testing.T) {
+		item := config.WidgetItem{}
+		ctx := RenderContext{Data: &status.StatusJSON{
+			Cost: &status.CostInfo{TotalDurationMS: floatPtr(5_400_000)}, // 1h30m
+		}}
+		assert.Equal(t, "1h30m/5h", w.Render(&item, ctx, &settings))
+	})
+
+	t.Run("time mode less than a minute", func(t *testing.T) {
+		item := config.WidgetItem{}
+		ctx := RenderContext{Data: &status.StatusJSON{
+			Cost: &status.CostInfo{TotalDurationMS: floatPtr(30_000)},
+		}}
+		assert.Equal(t, "<1m/5h", w.Render(&item, ctx, &settings))
+	})
+
+	t.Run("time mode hours only", func(t *testing.T) {
+		item := config.WidgetItem{}
+		ctx := RenderContext{Data: &status.StatusJSON{
+			Cost: &status.CostInfo{TotalDurationMS: floatPtr(7_200_000)}, // 2h
+		}}
+		assert.Equal(t, "2h/5h", w.Render(&item, ctx, &settings))
+	})
+
+	t.Run("clamped at 5h", func(t *testing.T) {
+		item := config.WidgetItem{}
+		ctx := RenderContext{Data: &status.StatusJSON{
+			Cost: &status.CostInfo{TotalDurationMS: floatPtr(20_000_000)}, // >5h
+		}}
+		assert.Equal(t, "5h/5h", w.Render(&item, ctx, &settings))
+	})
+
+	t.Run("percentage mode", func(t *testing.T) {
+		item := config.WidgetItem{Metadata: map[string]string{"display": "percentage"}}
+		ctx := RenderContext{Data: &status.StatusJSON{
+			Cost: &status.CostInfo{TotalDurationMS: floatPtr(9_000_000)}, // 2.5h = 50%
+		}}
+		assert.Equal(t, "50%", w.Render(&item, ctx, &settings))
+	})
+
+	t.Run("progress mode", func(t *testing.T) {
+		item := config.WidgetItem{Metadata: map[string]string{"display": "progress"}}
+		ctx := RenderContext{Data: &status.StatusJSON{
+			Cost: &status.CostInfo{TotalDurationMS: floatPtr(9_000_000)}, // 50%
+		}}
+		result := w.Render(&item, ctx, &settings)
+		assert.Contains(t, result, "[")
+		assert.Contains(t, result, "]")
+		assert.Contains(t, result, "50%")
+	})
+
+	t.Run("nil cost returns empty", func(t *testing.T) {
+		item := config.WidgetItem{}
+		ctx := RenderContext{Data: &status.StatusJSON{}}
+		assert.Empty(t, w.Render(&item, ctx, &settings))
+	})
+
+	t.Run("nil data returns empty", func(t *testing.T) {
+		item := config.WidgetItem{}
+		ctx := RenderContext{Data: nil}
+		assert.Empty(t, w.Render(&item, ctx, &settings))
+	})
+
+	t.Run("transcript fallback with temp file", func(t *testing.T) {
+		// Create a temp JSONL file with a timestamp.
+		tmpFile, err := os.CreateTemp("", "transcript-*.jsonl")
+		require.NoError(t, err)
+		defer os.Remove(tmpFile.Name())
+
+		// Write a JSONL entry with a timestamp 1 hour ago.
+		ts := time.Now().Add(-1 * time.Hour).Format(time.RFC3339)
+		_, err = tmpFile.WriteString(`{"timestamp":"` + ts + `","type":"start"}` + "\n")
+		require.NoError(t, err)
+		tmpFile.Close()
+
+		item := config.WidgetItem{}
+		ctx := RenderContext{Data: &status.StatusJSON{
+			TranscriptPath: tmpFile.Name(),
+		}}
+		result := w.Render(&item, ctx, &settings)
+		// Should show approximately 1h/5h (could be 59m or 1h depending on timing).
+		assert.NotEmpty(t, result)
+		assert.Contains(t, result, "/5h")
+	})
+
+	assert.Equal(t, defaultDimColor, w.DefaultColor())
+	assert.False(t, w.SupportsRawValue())
+}
+
+func TestStripANSI(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"no ANSI", "hello", "hello"},
+		{"color code", "\033[32mgreen\033[0m", "green"},
+		{"bold", "\033[1mbold\033[0m", "bold"},
+		{"multiple codes", "\033[1;32mbold green\033[0m", "bold green"},
+		{"empty string", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, stripANSI(tt.input))
+		})
+	}
 }

--- a/rfcs/003_remaining_widgets.md
+++ b/rfcs/003_remaining_widgets.md
@@ -1,16 +1,14 @@
 # RFC 003: Remaining Widget Implementation
 
-Status: Draft
+Status: Completed
 Author: @moond4rk
 Date: 2026-02-15
 
 ## Summary
 
-This RFC tracks the remaining widgets to implement for feature parity with the TypeScript ccstatusline project, plus ccstatus-exclusive widgets from the Claude Code JSON API.
+This RFC tracked the remaining widgets to implement for feature parity with the TypeScript ccstatusline project, plus ccstatus-exclusive widgets from the Claude Code JSON API.
 
-## Current State
-
-ccstatus has 27 registered widgets. The TypeScript ccstatusline has 21 widgets. There is significant overlap but each project has unique widgets the other lacks.
+All widgets are now implemented. ccstatus has 36 registered widgets, achieving 100% coverage of the official Claude Code JSON schema.
 
 ## Comparison Matrix
 
@@ -18,11 +16,11 @@ ccstatus has 27 registered widgets. The TypeScript ccstatusline has 21 widgets. 
 |--------|:---:|:---:|--------|
 | model | Y | Y | Done |
 | version | Y | Y | Done |
-| output-style | - | Y | **TODO** |
-| session-id | - | Y (claude-session-id) | **TODO** |
+| output-style | Y | Y | Done |
+| session-id | Y | Y (claude-session-id) | Done |
 | git-branch | Y | Y | Done |
 | git-changes | Y | Y | Done (different format) |
-| git-worktree | - | Y | **TODO** |
+| git-worktree | Y | Y | Done |
 | tokens-input | Y | Y | Done |
 | tokens-output | Y | Y | Done |
 | tokens-cached | Y | Y | Done |
@@ -34,19 +32,19 @@ ccstatus has 27 registered widgets. The TypeScript ccstatusline has 21 widgets. 
 | context-percentage | Y | Y | Done |
 | context-percentage-usable | Y | Y | Done |
 | remaining-percentage | Y | - | Done (Go exclusive) |
-| block-timer | - | Y | **TODO** (high effort) |
+| block-timer | Y | Y | Done |
 | session-clock | Y | Y | Done |
 | session-cost | Y | Y | Done |
 | api-duration | Y | - | Done (Go exclusive) |
 | current-working-dir | Y | Y | Done |
 | project-dir | Y | - | Done (Go exclusive) |
 | transcript-path | Y | - | Done (Go exclusive) |
-| terminal-width | - | Y | **TODO** |
+| terminal-width | Y | Y | Done |
 | custom-text | Y | Y | Done |
-| custom-command | - | Y | **TODO** (high value) |
-| vim-mode | - | - | **TODO** (both planned) |
-| agent-name | - | - | **TODO** (both planned) |
-| exceeds-200k | - | - | **TODO** (both planned) |
+| custom-command | Y | Y | Done |
+| vim-mode | Y | - | Done (Go exclusive) |
+| agent-name | Y | - | Done (Go exclusive) |
+| exceeds-200k | Y | - | Done (Go exclusive) |
 | lines-changed | Y | - | Done (Go exclusive) |
 | lines-added | Y | - | Done (Go exclusive) |
 | lines-removed | Y | - | Done (Go exclusive) |
@@ -55,107 +53,34 @@ ccstatus has 27 registered widgets. The TypeScript ccstatusline has 21 widgets. 
 
 ### Summary
 
-- **ccstatus-exclusive widgets (9)**: current-usage-input, current-usage-output, cache-creation, remaining-percentage, api-duration, project-dir, transcript-path, lines-changed/added/removed
-- **ccstatusline-exclusive widgets (6)**: output-style, session-id, git-worktree, block-timer, terminal-width, custom-command
-- **Both planned but neither implemented (3)**: vim-mode, agent-name, exceeds-200k
+- **Total widgets**: 36 registered
+- **ccstatus-exclusive widgets (15)**: current-usage-input, current-usage-output, cache-creation, remaining-percentage, api-duration, project-dir, transcript-path, lines-changed/added/removed, vim-mode, agent-name, exceeds-200k
+- **Shared with ccstatusline (21)**: model, version, output-style, session-id, git-branch, git-changes, git-worktree, tokens-input/output/cached/total, context-length, context-percentage, context-percentage-usable, block-timer, session-clock, session-cost, current-working-dir, terminal-width, custom-text, custom-command, separator, flex-separator
 
-## Widgets to Implement
+## Implementation Notes
 
-### Priority 1 - High Value
+### Generic Widget Patterns
 
-#### 1. `custom-command`
+To avoid code duplication flagged by the `dupl` linter, several generic widget types were created:
 
-Execute arbitrary shell commands and display output. Core extensibility widget.
+- **`tokenWidget`** - Parameterized by extractor function. Used for 7 token widgets.
+- **`percentageWidget`** - Parameterized by extractor function. Used for context-percentage and remaining-percentage.
+- **`stringFieldWidget`** - Parameterized by extractor, color, name, description. Used for output-style, vim-mode, and agent-name.
 
-- **Source**: Shell command execution
-- **Config fields**: `customCommand` (string), `timeout` (ms), `maxWidth` (int)
-- **Format**: stdout of the command (first line, trimmed)
-- **Complexity**: Medium - need subprocess execution with timeout, security considerations
-- **TS reference**: Passes JSON input via stdin to the command, supports `preserveColors` metadata
+### block-timer
 
-#### 2. `output-style`
+Uses `cost.total_duration_ms` as primary data source (available from Claude Code JSON). Falls back to JSONL transcript parsing (`internal/jsonl/`) when duration data is unavailable. Supports three display modes via `metadata["display"]`:
+- `"time"` (default): `2h15m/5h`
+- `"progress"`: `[=====>    ] 50%`
+- `"percentage"`: `50%`
 
-Display the currently configured output style.
+### custom-command
 
-- **Source**: `StatusJSON.OutputStyle.Name`
-- **Format**: `text` / `json` / `stream-json`
-- **Default color**: `brightBlack`
-- **Complexity**: Low - single field read
-- **Supports rawValue**: no
+Executes shell commands via `sh -c` with configurable timeout (default 3s). Pipes full JSON session data to stdin. Supports `preserveColors` to retain ANSI escape sequences, `maxWidth` to truncate output.
 
-#### 3. `session-id`
+### git-worktree
 
-Display the Claude Code session ID.
-
-- **Source**: `StatusJSON.SessionID`
-- **Format**: Full UUID (rawValue) or truncated (normal)
-- **Default color**: `brightBlack`
-- **Complexity**: Low - single field read
-- **Supports rawValue**: yes (full vs truncated)
-
-### Priority 2 - Useful
-
-#### 4. `git-worktree`
-
-Display the current git worktree name.
-
-- **Source**: Git command (`git rev-parse --git-dir`)
-- **Format**: Worktree name or empty
-- **Default color**: `magenta`
-- **Complexity**: Medium - need to detect worktree vs main repo
-- **TS reference**: Has `hideNoGit` metadata option
-
-#### 5. `terminal-width`
-
-Display the current terminal width in columns. Primarily for debugging.
-
-- **Source**: `RenderContext.TerminalWidth` (already available)
-- **Format**: `120` (columns)
-- **Default color**: `brightBlack`
-- **Complexity**: Very low - data already in RenderContext
-- **Supports rawValue**: no
-
-#### 6. `block-timer`
-
-Display time elapsed in current 5-hour Claude Code session block.
-
-- **Source**: JSONL transcript file (parsed via `internal/jsonl/`)
-- **Format**: Three display modes - time (`2h15m`), progress bar (`[=====>    ]`), progress-short (`45%`)
-- **Default color**: `brightBlack`
-- **Complexity**: High - requires JSONL parsing, block detection, multiple display modes
-- **TS reference**: 3 modes toggled via metadata `display` field
-
-### Priority 3 - Narrow Use Case
-
-#### 7. `vim-mode`
-
-Display the current vim mode when vim keybindings are enabled.
-
-- **Source**: `StatusJSON.Vim.Mode`
-- **Format**: `NORMAL` / `INSERT` / `VISUAL`
-- **Default color**: `yellow`
-- **Complexity**: Low - single field, only renders when vim is enabled
-- **Note**: Field exists in StatusJSON but no widget yet in either project
-
-#### 8. `agent-name`
-
-Display the agent name when running with `--agent` flag.
-
-- **Source**: `StatusJSON.Agent.Name`
-- **Format**: Agent name string
-- **Default color**: `cyan`
-- **Complexity**: Low - single field, only renders in agent mode
-- **Note**: Field exists in StatusJSON but no widget yet in either project
-
-#### 9. `exceeds-200k`
-
-Warning indicator when token count exceeds 200k threshold.
-
-- **Source**: `StatusJSON.Exceeds200K`
-- **Format**: Warning text (e.g., `>200k`) or empty
-- **Default color**: `red`
-- **Complexity**: Low - boolean field check
-- **Note**: Field exists in StatusJSON but no widget yet in either project
+Detects linked worktrees by checking if `git rev-parse --git-dir` returns a path containing `/worktrees/`. Returns the worktree name or empty string for main working tree.
 
 ## Notable Feature Differences
 
@@ -168,22 +93,10 @@ Warning indicator when token count exceeds 200k threshold.
 
 ### ccstatus (Go) has but ccstatusline (TS) does not
 
-1. **lines-changed/added/removed**: Session-level code change metrics from Claude Code cost data
+1. **lines-changed/added/removed**: Real git diff stats (uncommitted changes)
 2. **current-usage-input/output**: Per-round token metrics
 3. **cache-creation**: Cache creation token visibility
 4. **remaining-percentage**: Explicit remaining context percentage
 5. **api-duration**: API response time widget
 6. **project-dir / transcript-path**: Additional environment info
-
-## Implementation Order
-
-Suggested implementation sequence:
-
-1. `output-style` + `session-id` (trivial, same session)
-2. `terminal-width` (trivial, data already available)
-3. `vim-mode` + `agent-name` + `exceeds-200k` (low effort, complete JSON coverage)
-4. `custom-command` (medium effort, high user value)
-5. `git-worktree` (medium effort, requires git integration)
-6. `block-timer` (high effort, requires JSONL parsing infrastructure)
-
-After all widgets: 36 total registered widgets.
+7. **vim-mode / agent-name / exceeds-200k**: From official Claude Code JSON fields


### PR DESCRIPTION
## Summary

- Add 9 new widgets: `output-style`, `session-id`, `terminal-width`, `vim-mode`, `agent-name`, `exceeds-200k`, `custom-command`, `git-worktree`, `block-timer`
- Introduce `stringFieldWidget` generic pattern to eliminate code duplication for simple string field extraction
- Add `internal/jsonl` package for JSONL transcript timestamp parsing (block-timer fallback)
- Add `internal/git/worktree.go` for linked worktree detection
- Total registered widgets: **36** (up from 27)

### New Widget Details

| Widget | Source | Description |
|--------|--------|-------------|
| `output-style` | JSON | Current output style name (text/json/stream-json) |
| `session-id` | JSON | Session ID (8-char truncated, full UUID via rawValue) |
| `terminal-width` | System | Terminal width in columns |
| `vim-mode` | JSON | Vim mode indicator (only when vim enabled) |
| `agent-name` | JSON | Agent name (only with --agent flag) |
| `exceeds-200k` | JSON | Warning when tokens exceed 200k threshold |
| `custom-command` | System | Shell command output (configurable timeout, ANSI stripping, maxWidth) |
| `git-worktree` | Git | Current git worktree name |
| `block-timer` | JSON/JSONL | 5-hour session block timer (time/progress/percentage modes) |

### Design Patterns

- **`stringFieldWidget`**: Generic widget for simple string fields, used by `output-style`, `vim-mode`, `agent-name` to avoid duplication
- **`custom-command`**: Executes via `sh -c` with 3s default timeout, pipes JSON to stdin, strips ANSI by default
- **`block-timer`**: Uses `cost.total_duration_ms` as primary source, falls back to JSONL transcript first-line timestamp parsing

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] Lint clean (`golangci-lint run` - 0 issues)
- [x] Build succeeds (`go build -o ccstatus ./cmd/ccstatus`)
- [x] New tests for all 9 widgets in `widget_test.go`
- [x] New tests for JSONL reader in `reader_test.go`
- [x] `ccstatus widgets` lists all 36 widget types