### PR TITLE
refactor: fix Go naming conventions across all packages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ echo '{"model":{"id":"claude-sonnet-4-5","display_name":"Sonnet"},"context_windo
 | `internal/config/` | Settings loading, defaults, validation, migration |
 | `internal/render/` | Status line rendering, color application, truncation |
 | `internal/widget/` | Widget interface, registry, all widget implementations |
-| `internal/status/` | StatusJSON input struct parsing (official Claude Code JSON schema) |
+| `internal/status/` | Session input struct parsing (official Claude Code JSON schema) |
 | `internal/jsonl/` | JSONL transcript parsing (block-timer widget only) |
 | `internal/color/` | ANSI color output via fatih/color, standard 16 named colors |
 | `internal/jsonl/` | JSONL transcript parsing (block-timer widget) |

--- a/cmd/ccstatus/cmd_dump.go
+++ b/cmd/ccstatus/cmd_dump.go
@@ -57,7 +57,7 @@ func runDump(cmd *cobra.Command, _ []string) error {
 
 	ctx := widget.RenderContext{
 		Data:          statusData,
-		TerminalWidth: terminal.GetWidth(),
+		TerminalWidth: terminal.Width(),
 	}
 
 	for _, line := range settings.Lines {

--- a/cmd/ccstatus/cmd_init.go
+++ b/cmd/ccstatus/cmd_init.go
@@ -22,7 +22,7 @@ func newInitCmd() *cobra.Command {
 
 func runInit(cmd *cobra.Command, _ []string) error {
 	force, _ := cmd.Flags().GetBool("force")
-	path := config.ConfigPath()
+	path := config.Path()
 
 	if !force {
 		if _, err := os.Stat(path); err == nil {

--- a/cmd/ccstatus/main.go
+++ b/cmd/ccstatus/main.go
@@ -65,7 +65,7 @@ func runStatusLine(_ *cobra.Command, _ []string) error {
 
 	ctx := widget.RenderContext{
 		Data:          statusData,
-		TerminalWidth: terminal.GetWidth(),
+		TerminalWidth: terminal.Width(),
 	}
 
 	for _, line := range settings.Lines {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,8 +58,8 @@ func DefaultSettings() Settings {
 	}
 }
 
-// ConfigDir returns the ccstatus configuration directory path.
-func ConfigDir() string {
+// Dir returns the ccstatus configuration directory path.
+func Dir() string {
 	if dir := os.Getenv("XDG_CONFIG_HOME"); dir != "" {
 		return filepath.Join(dir, configDirName)
 	}
@@ -70,14 +70,14 @@ func ConfigDir() string {
 	return filepath.Join(home, ".config", configDirName)
 }
 
-// ConfigPath returns the full path to the settings.json file.
-func ConfigPath() string {
-	return filepath.Join(ConfigDir(), configFileName)
+// Path returns the full path to the settings.json file.
+func Path() string {
+	return filepath.Join(Dir(), configFileName)
 }
 
 // Load reads and parses the settings file. Returns defaults if the file does not exist.
 func Load() (Settings, error) {
-	path := ConfigPath()
+	path := Path()
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -94,7 +94,7 @@ func Load() (Settings, error) {
 
 // Save writes the settings to the configuration file.
 func Save(s *Settings) error {
-	dir := ConfigDir()
+	dir := Dir()
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
@@ -103,5 +103,5 @@ func Save(s *Settings) error {
 		return err
 	}
 	data = append(data, '\n')
-	return os.WriteFile(ConfigPath(), data, 0o600)
+	return os.WriteFile(Path(), data, 0o600)
 }

--- a/internal/git/changes.go
+++ b/internal/git/changes.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 )
 
-// GetChanges returns the number of uncommitted changes (staged + unstaged + untracked).
+// Changes returns the number of uncommitted changes (staged + unstaged + untracked).
 // Returns 0 if not in a git repository or on error.
-func GetChanges() int {
+func Changes() int {
 	ctx, cancel := context.WithTimeout(context.Background(), gitTimeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "git", "status", "--porcelain")

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -13,10 +13,10 @@ type DiffStat struct {
 	Removed int
 }
 
-// GetDiffStat returns the number of lines added and removed in the working tree
+// Diff returns the number of lines added and removed in the working tree
 // (staged + unstaged) compared to HEAD. Returns zero values if not in a git
 // repository or on error.
-func GetDiffStat() DiffStat {
+func Diff() DiffStat {
 	// Staged changes (index vs HEAD)
 	staged := diffShortStat("--cached")
 	// Unstaged changes (working tree vs index)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -10,8 +10,8 @@ import (
 
 const gitTimeout = 5 * time.Second
 
-// GetBranch returns the current git branch name, or empty string if not in a git repository.
-func GetBranch() string {
+// Branch returns the current git branch name, or empty string if not in a git repository.
+func Branch() string {
 	ctx, cancel := context.WithTimeout(context.Background(), gitTimeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--abbrev-ref", "HEAD")

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 )
 
-// GetWorktree returns the worktree name if the current directory is a git worktree.
+// Worktree returns the worktree name if the current directory is a git worktree.
 // Returns empty string if in the main working tree or not in a git repository.
-func GetWorktree() string {
+func Worktree() string {
 	ctx, cancel := context.WithTimeout(context.Background(), gitTimeout)
 	defer cancel()
 

--- a/internal/jsonl/reader.go
+++ b/internal/jsonl/reader.go
@@ -13,9 +13,9 @@ type entry struct {
 	Timestamp string `json:"timestamp"`
 }
 
-// GetSessionStart reads the first entry from a JSONL transcript file and returns
+// SessionStart reads the first entry from a JSONL transcript file and returns
 // its timestamp. Returns zero time if the file cannot be read or parsed.
-func GetSessionStart(path string) time.Time {
+func SessionStart(path string) time.Time {
 	if path == "" {
 		return time.Time{}
 	}

--- a/internal/jsonl/reader_test.go
+++ b/internal/jsonl/reader_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetSessionStart(t *testing.T) {
+func TestSessionStart(t *testing.T) {
 	t.Run("valid RFC3339 timestamp", func(t *testing.T) {
 		f, err := os.CreateTemp("", "test-*.jsonl")
 		require.NoError(t, err)
@@ -19,7 +19,7 @@ func TestGetSessionStart(t *testing.T) {
 		require.NoError(t, err)
 		f.Close()
 
-		result := GetSessionStart(f.Name())
+		result := SessionStart(f.Name())
 		assert.Equal(t, 2025, result.Year())
 		assert.Equal(t, time.January, result.Month())
 		assert.Equal(t, 15, result.Day())
@@ -36,7 +36,7 @@ func TestGetSessionStart(t *testing.T) {
 		require.NoError(t, err)
 		f.Close()
 
-		result := GetSessionStart(f.Name())
+		result := SessionStart(f.Name())
 		assert.False(t, result.IsZero())
 		assert.Equal(t, 10, result.Hour())
 	})
@@ -52,7 +52,7 @@ func TestGetSessionStart(t *testing.T) {
 		require.NoError(t, err)
 		f.Close()
 
-		result := GetSessionStart(f.Name())
+		result := SessionStart(f.Name())
 		assert.Equal(t, 10, result.Hour())
 	})
 
@@ -62,7 +62,7 @@ func TestGetSessionStart(t *testing.T) {
 		defer os.Remove(f.Name())
 		f.Close()
 
-		result := GetSessionStart(f.Name())
+		result := SessionStart(f.Name())
 		assert.True(t, result.IsZero())
 	})
 
@@ -75,7 +75,7 @@ func TestGetSessionStart(t *testing.T) {
 		require.NoError(t, err)
 		f.Close()
 
-		result := GetSessionStart(f.Name())
+		result := SessionStart(f.Name())
 		assert.True(t, result.IsZero())
 	})
 
@@ -88,17 +88,17 @@ func TestGetSessionStart(t *testing.T) {
 		require.NoError(t, err)
 		f.Close()
 
-		result := GetSessionStart(f.Name())
+		result := SessionStart(f.Name())
 		assert.True(t, result.IsZero())
 	})
 
 	t.Run("nonexistent file returns zero", func(t *testing.T) {
-		result := GetSessionStart("/nonexistent/path/transcript.jsonl")
+		result := SessionStart("/nonexistent/path/transcript.jsonl")
 		assert.True(t, result.IsZero())
 	})
 
 	t.Run("empty path returns zero", func(t *testing.T) {
-		result := GetSessionStart("")
+		result := SessionStart("")
 		assert.True(t, result.IsZero())
 	})
 }

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -18,7 +18,7 @@ func TestRenderLine(t *testing.T) {
 		name          string
 		items         []config.WidgetItem
 		settings      config.Settings
-		data          *status.StatusJSON
+		data          *status.Session
 		terminalWidth int
 		check         func(t *testing.T, result string)
 	}{
@@ -28,7 +28,7 @@ func TestRenderLine(t *testing.T) {
 				{ID: "1", Type: "model", Color: "cyan"},
 			},
 			settings: config.Settings{ColorLevel: 2, DefaultPadding: " "},
-			data: &status.StatusJSON{
+			data: &status.Session{
 				Model: status.ModelField{ID: "claude-sonnet-4-5", DisplayName: "Sonnet"},
 			},
 			check: func(t *testing.T, result string) {
@@ -45,7 +45,7 @@ func TestRenderLine(t *testing.T) {
 				{ID: "3", Type: "version", Color: "brightBlack"},
 			},
 			settings: config.Settings{ColorLevel: 2, DefaultSeparator: "|", DefaultPadding: " "},
-			data: &status.StatusJSON{
+			data: &status.Session{
 				Model:   status.ModelField{ID: "claude-sonnet-4-5", DisplayName: "Sonnet"},
 				Version: "1.0.80",
 			},
@@ -65,7 +65,7 @@ func TestRenderLine(t *testing.T) {
 				{ID: "5", Type: "custom-text", CustomText: "hello"},
 			},
 			settings: config.Settings{ColorLevel: 2, DefaultSeparator: "|", DefaultPadding: " "},
-			data: &status.StatusJSON{
+			data: &status.Session{
 				Model: status.ModelField{DisplayName: "Sonnet"},
 			},
 			check: func(t *testing.T, result string) {
@@ -82,7 +82,7 @@ func TestRenderLine(t *testing.T) {
 				{ID: "3", Type: "version"},
 			},
 			settings: config.Settings{ColorLevel: 2, DefaultSeparator: "|", DefaultPadding: " "},
-			data:     &status.StatusJSON{},
+			data:     &status.Session{},
 			check: func(t *testing.T, result string) {
 				t.Helper()
 				assert.Empty(t, result)
@@ -94,7 +94,7 @@ func TestRenderLine(t *testing.T) {
 				{ID: "1", Type: "model", Color: "cyan"},
 			},
 			settings: config.Settings{ColorLevel: 0, DefaultPadding: " "},
-			data: &status.StatusJSON{
+			data: &status.Session{
 				Model: status.ModelField{DisplayName: "Sonnet"},
 			},
 			check: func(t *testing.T, result string) {
@@ -110,7 +110,7 @@ func TestRenderLine(t *testing.T) {
 				{ID: "3", Type: "nonexistent-widget"},
 			},
 			settings: config.Settings{ColorLevel: 2, DefaultSeparator: "|", DefaultPadding: " "},
-			data: &status.StatusJSON{
+			data: &status.Session{
 				Model: status.ModelField{DisplayName: "Sonnet"},
 			},
 			check: func(t *testing.T, result string) {
@@ -125,7 +125,7 @@ func TestRenderLine(t *testing.T) {
 				{ID: "1", Type: "custom-text", CustomText: "This is a very long status line text"},
 			},
 			settings:      config.Settings{ColorLevel: 0, DefaultPadding: " "},
-			data:          &status.StatusJSON{},
+			data:          &status.Session{},
 			terminalWidth: 10,
 			check: func(t *testing.T, result string) {
 				t.Helper()
@@ -141,7 +141,7 @@ func TestRenderLine(t *testing.T) {
 				{ID: "3", Type: "context-percentage"},
 			},
 			settings: config.Settings{ColorLevel: 0, DefaultSeparator: "|", DefaultPadding: " "},
-			data: &status.StatusJSON{
+			data: &status.Session{
 				ContextWindow: &status.ContextWindow{
 					TotalInputTokens: intPtr(50_000),
 					UsedPercentage:   func() *float64 { v := 25.0; return &v }(),
@@ -160,7 +160,7 @@ func TestRenderLine(t *testing.T) {
 				{ID: "3", Type: "custom-text", CustomText: "R"},
 			},
 			settings:      config.Settings{ColorLevel: 0, DefaultPadding: " "},
-			data:          &status.StatusJSON{},
+			data:          &status.Session{},
 			terminalWidth: 20,
 			check: func(t *testing.T, result string) {
 				t.Helper()
@@ -177,7 +177,7 @@ func TestRenderLine(t *testing.T) {
 				{ID: "3", Type: "custom-text", CustomText: "R"},
 			},
 			settings: config.Settings{ColorLevel: 0, DefaultPadding: " "},
-			data:     &status.StatusJSON{},
+			data:     &status.Session{},
 			check: func(t *testing.T, result string) {
 				t.Helper()
 				assert.Equal(t, "L R", result)

--- a/internal/status/format.go
+++ b/internal/status/format.go
@@ -12,8 +12,8 @@ const (
 	longMaxTokens      = 1_000_000
 )
 
-// ContextConfig holds resolved context window size information.
-type ContextConfig struct {
+// WindowLimits holds resolved context window size information.
+type WindowLimits struct {
 	MaxTokens    int
 	UsableTokens int
 }
@@ -30,13 +30,13 @@ func FormatTokens(count int) string {
 	return strconv.Itoa(count)
 }
 
-// GetContextConfig resolves context window size.
+// ContextConfig resolves context window size.
 // Primary: use context_window.context_window_size from JSON input.
 // Fallback: heuristic based on model ID (for older Claude Code versions).
-func GetContextConfig(data *StatusJSON) ContextConfig {
+func ContextConfig(data *Session) WindowLimits {
 	if data.ContextWindow != nil && data.ContextWindow.ContextWindowSize != nil {
 		size := *data.ContextWindow.ContextWindowSize
-		return ContextConfig{
+		return WindowLimits{
 			MaxTokens:    size,
 			UsableTokens: size * defaultUsableRatio / 100,
 		}
@@ -44,28 +44,28 @@ func GetContextConfig(data *StatusJSON) ContextConfig {
 
 	lower := strings.ToLower(data.Model.ID)
 	if strings.Contains(lower, "claude-sonnet-4-5") && strings.Contains(lower, "[1m]") {
-		return ContextConfig{
+		return WindowLimits{
 			MaxTokens:    longMaxTokens,
 			UsableTokens: longMaxTokens * defaultUsableRatio / 100,
 		}
 	}
-	return ContextConfig{
+	return WindowLimits{
 		MaxTokens:    defaultMaxTokens,
 		UsableTokens: defaultMaxTokens * defaultUsableRatio / 100,
 	}
 }
 
-// GetContextPercentage returns the context usage percentage.
+// ContextPercentage returns the context usage percentage.
 // Primary: use pre-calculated used_percentage from JSON input.
 // Fallback: calculate from current_usage tokens and context_window_size.
-func GetContextPercentage(data *StatusJSON) float64 {
+func ContextPercentage(data *Session) float64 {
 	if data.ContextWindow != nil && data.ContextWindow.UsedPercentage != nil {
 		return *data.ContextWindow.UsedPercentage
 	}
 	if data.ContextWindow != nil && data.ContextWindow.CurrentUsage != nil {
 		cu := data.ContextWindow.CurrentUsage
 		contextLength := cu.InputTokens + cu.CacheCreationInputTokens + cu.CacheReadInputTokens
-		cfg := GetContextConfig(data)
+		cfg := ContextConfig(data)
 		if cfg.MaxTokens == 0 {
 			return 0
 		}
@@ -78,14 +78,14 @@ func GetContextPercentage(data *StatusJSON) float64 {
 	return 0
 }
 
-// GetRemainingPercentage returns the remaining context window percentage.
+// RemainingPercentage returns the remaining context window percentage.
 // Primary: use pre-calculated remaining_percentage from JSON input.
 // Fallback: calculate as 100 - used_percentage.
-func GetRemainingPercentage(data *StatusJSON) float64 {
+func RemainingPercentage(data *Session) float64 {
 	if data.ContextWindow != nil && data.ContextWindow.RemainingPercentage != nil {
 		return *data.ContextWindow.RemainingPercentage
 	}
-	used := GetContextPercentage(data)
+	used := ContextPercentage(data)
 	if used == 0 {
 		return 0
 	}
@@ -96,9 +96,9 @@ func GetRemainingPercentage(data *StatusJSON) float64 {
 	return remaining
 }
 
-// GetContextLength returns the total input token count (context length).
+// ContextLength returns the total input token count (context length).
 // This is the sum of input_tokens + cache_creation_input_tokens + cache_read_input_tokens.
-func GetContextLength(data *StatusJSON) int {
+func ContextLength(data *Session) int {
 	if data.ContextWindow == nil || data.ContextWindow.CurrentUsage == nil {
 		return 0
 	}

--- a/internal/status/format_test.go
+++ b/internal/status/format_test.go
@@ -28,18 +28,18 @@ func TestFormatTokens(t *testing.T) {
 	}
 }
 
-func TestGetContextConfig(t *testing.T) {
+func TestContextConfig(t *testing.T) {
 	intPtr := func(v int) *int { return &v }
 
 	tests := []struct {
 		name       string
-		data       *StatusJSON
+		data       *Session
 		wantMax    int
 		wantUsable int
 	}{
 		{
 			name: "from context_window_size",
-			data: &StatusJSON{
+			data: &Session{
 				ContextWindow: &ContextWindow{ContextWindowSize: intPtr(200_000)},
 			},
 			wantMax:    200_000,
@@ -47,7 +47,7 @@ func TestGetContextConfig(t *testing.T) {
 		},
 		{
 			name: "1M context window",
-			data: &StatusJSON{
+			data: &Session{
 				ContextWindow: &ContextWindow{ContextWindowSize: intPtr(1_000_000)},
 			},
 			wantMax:    1_000_000,
@@ -55,13 +55,13 @@ func TestGetContextConfig(t *testing.T) {
 		},
 		{
 			name:       "fallback to default",
-			data:       &StatusJSON{Model: ModelField{ID: "claude-sonnet-4-5"}},
+			data:       &Session{Model: ModelField{ID: "claude-sonnet-4-5"}},
 			wantMax:    200_000,
 			wantUsable: 160_000,
 		},
 		{
 			name:       "empty data defaults",
-			data:       &StatusJSON{},
+			data:       &Session{},
 			wantMax:    200_000,
 			wantUsable: 160_000,
 		},
@@ -69,32 +69,32 @@ func TestGetContextConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg := GetContextConfig(tt.data)
+			cfg := ContextConfig(tt.data)
 			assert.Equal(t, tt.wantMax, cfg.MaxTokens)
 			assert.Equal(t, tt.wantUsable, cfg.UsableTokens)
 		})
 	}
 }
 
-func TestGetContextPercentage(t *testing.T) {
+func TestContextPercentage(t *testing.T) {
 	floatPtr := func(v float64) *float64 { return &v }
 	intPtr := func(v int) *int { return &v }
 
 	tests := []struct {
 		name string
-		data *StatusJSON
+		data *Session
 		want float64
 	}{
 		{
 			name: "from used_percentage",
-			data: &StatusJSON{
+			data: &Session{
 				ContextWindow: &ContextWindow{UsedPercentage: floatPtr(25.5)},
 			},
 			want: 25.5,
 		},
 		{
 			name: "calculated from current_usage",
-			data: &StatusJSON{
+			data: &Session{
 				ContextWindow: &ContextWindow{
 					ContextWindowSize: intPtr(200_000),
 					CurrentUsage: &CurrentUsage{
@@ -108,7 +108,7 @@ func TestGetContextPercentage(t *testing.T) {
 		},
 		{
 			name: "capped at 100",
-			data: &StatusJSON{
+			data: &Session{
 				ContextWindow: &ContextWindow{
 					ContextWindowSize: intPtr(100),
 					CurrentUsage: &CurrentUsage{
@@ -120,12 +120,12 @@ func TestGetContextPercentage(t *testing.T) {
 		},
 		{
 			name: "nil context window",
-			data: &StatusJSON{},
+			data: &Session{},
 			want: 0,
 		},
 		{
 			name: "no current usage",
-			data: &StatusJSON{
+			data: &Session{
 				ContextWindow: &ContextWindow{},
 			},
 			want: 0,
@@ -134,20 +134,20 @@ func TestGetContextPercentage(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.InDelta(t, tt.want, GetContextPercentage(tt.data), 0.01)
+			assert.InDelta(t, tt.want, ContextPercentage(tt.data), 0.01)
 		})
 	}
 }
 
-func TestGetContextLength(t *testing.T) {
+func TestContextLength(t *testing.T) {
 	tests := []struct {
 		name string
-		data *StatusJSON
+		data *Session
 		want int
 	}{
 		{
 			name: "sums all input tokens",
-			data: &StatusJSON{
+			data: &Session{
 				ContextWindow: &ContextWindow{
 					CurrentUsage: &CurrentUsage{
 						InputTokens:              10_000,
@@ -160,19 +160,19 @@ func TestGetContextLength(t *testing.T) {
 		},
 		{
 			name: "nil context window",
-			data: &StatusJSON{},
+			data: &Session{},
 			want: 0,
 		},
 		{
 			name: "nil current usage",
-			data: &StatusJSON{ContextWindow: &ContextWindow{}},
+			data: &Session{ContextWindow: &ContextWindow{}},
 			want: 0,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, GetContextLength(tt.data))
+			assert.Equal(t, tt.want, ContextLength(tt.data))
 		})
 	}
 }

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 )
 
-// StatusJSON represents the JSON payload piped from Claude Code.
+// Session represents the JSON payload piped from Claude Code.
 // All fields are optional and may be absent or null.
-type StatusJSON struct {
+type Session struct {
 	Cwd            string         `json:"cwd,omitempty"`
 	SessionID      string         `json:"session_id,omitempty"`
 	TranscriptPath string         `json:"transcript_path,omitempty"`
@@ -23,9 +23,9 @@ type StatusJSON struct {
 	Agent          *AgentInfo     `json:"agent,omitempty"`
 }
 
-// Parse parses JSON data into StatusJSON.
-func Parse(data []byte) (*StatusJSON, error) {
-	var s StatusJSON
+// Parse parses JSON data into Session.
+func Parse(data []byte) (*Session, error) {
+	var s Session
 	if err := json.Unmarshal(data, &s); err != nil {
 		return nil, err
 	}
@@ -61,7 +61,7 @@ func (m *ModelField) UnmarshalJSON(data []byte) error {
 }
 
 // MarshalJSON serializes the ModelField as an object.
-func (m ModelField) MarshalJSON() ([]byte, error) {
+func (m *ModelField) MarshalJSON() ([]byte, error) {
 	obj := struct {
 		ID          string `json:"id"`
 		DisplayName string `json:"display_name"`

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -12,13 +12,13 @@ func TestParse(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   string
-		check   func(t *testing.T, s *StatusJSON)
+		check   func(t *testing.T, s *Session)
 		wantErr bool
 	}{
 		{
 			name:  "model as object",
 			input: `{"model":{"id":"claude-sonnet-4-5","display_name":"Sonnet"}}`,
-			check: func(t *testing.T, s *StatusJSON) {
+			check: func(t *testing.T, s *Session) {
 				t.Helper()
 				assert.Equal(t, "claude-sonnet-4-5", s.Model.ID)
 				assert.Equal(t, "Sonnet", s.Model.DisplayName)
@@ -27,7 +27,7 @@ func TestParse(t *testing.T) {
 		{
 			name:  "model as string",
 			input: `{"model":"claude-opus-4-6"}`,
-			check: func(t *testing.T, s *StatusJSON) {
+			check: func(t *testing.T, s *Session) {
 				t.Helper()
 				assert.Equal(t, "claude-opus-4-6", s.Model.ID)
 				assert.Equal(t, "Opus", s.Model.DisplayName)
@@ -36,7 +36,7 @@ func TestParse(t *testing.T) {
 		{
 			name:  "full official schema",
 			input: `{"cwd":"/test","session_id":"abc123","version":"1.0.80","model":{"id":"claude-opus-4-6","display_name":"Opus"},"workspace":{"current_dir":"/test","project_dir":"/project"},"cost":{"total_cost_usd":0.01234,"total_duration_ms":45000},"context_window":{"total_input_tokens":15234,"total_output_tokens":4521,"context_window_size":200000,"used_percentage":8,"remaining_percentage":92,"current_usage":{"input_tokens":8500,"output_tokens":1200,"cache_creation_input_tokens":5000,"cache_read_input_tokens":2000}},"exceeds_200k_tokens":false,"vim":{"mode":"NORMAL"},"agent":{"name":"security-reviewer"}}`,
-			check: func(t *testing.T, s *StatusJSON) {
+			check: func(t *testing.T, s *Session) {
 				t.Helper()
 				assert.Equal(t, "/test", s.Cwd)
 				assert.Equal(t, "abc123", s.SessionID)
@@ -80,7 +80,7 @@ func TestParse(t *testing.T) {
 		{
 			name:  "empty JSON object",
 			input: `{}`,
-			check: func(t *testing.T, s *StatusJSON) {
+			check: func(t *testing.T, s *Session) {
 				t.Helper()
 				assert.Empty(t, s.Model.ID)
 				assert.Nil(t, s.ContextWindow)
@@ -91,7 +91,7 @@ func TestParse(t *testing.T) {
 		{
 			name:  "null context_window.current_usage",
 			input: `{"context_window":{"used_percentage":null,"current_usage":null}}`,
-			check: func(t *testing.T, s *StatusJSON) {
+			check: func(t *testing.T, s *Session) {
 				t.Helper()
 				require.NotNil(t, s.ContextWindow)
 				assert.Nil(t, s.ContextWindow.UsedPercentage)
@@ -123,7 +123,7 @@ func TestParse(t *testing.T) {
 
 func TestModelField_MarshalJSON(t *testing.T) {
 	m := ModelField{ID: "claude-sonnet-4-5", DisplayName: "Sonnet"}
-	data, err := json.Marshal(m)
+	data, err := json.Marshal(&m)
 	require.NoError(t, err)
 
 	var result map[string]string

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -7,8 +7,8 @@ import (
 	"golang.org/x/term"
 )
 
-// GetWidth returns the terminal width in columns, or 0 if detection fails.
-func GetWidth() int {
+// Width returns the terminal width in columns, or 0 if detection fails.
+func Width() int {
 	width, _, err := term.GetSize(int(os.Stdout.Fd()))
 	if err != nil {
 		return 0

--- a/internal/widget/block_timer.go
+++ b/internal/widget/block_timer.go
@@ -70,7 +70,7 @@ func (w *BlockTimerWidget) getElapsed(ctx RenderContext) time.Duration {
 
 	// Fallback: parse JSONL transcript for session start time.
 	if ctx.Data.TranscriptPath != "" {
-		start := jsonl.GetSessionStart(ctx.Data.TranscriptPath)
+		start := jsonl.SessionStart(ctx.Data.TranscriptPath)
 		if !start.IsZero() {
 			return time.Since(start)
 		}

--- a/internal/widget/context_length.go
+++ b/internal/widget/context_length.go
@@ -13,7 +13,7 @@ func (w *ContextLengthWidget) Render(_ *config.WidgetItem, ctx RenderContext, _ 
 	if ctx.Data == nil {
 		return ""
 	}
-	length := status.GetContextLength(ctx.Data)
+	length := status.ContextLength(ctx.Data)
 	if length == 0 {
 		return ""
 	}

--- a/internal/widget/context_percentage.go
+++ b/internal/widget/context_percentage.go
@@ -7,8 +7,8 @@ import (
 	"github.com/moond4rk/ccstatus/internal/status"
 )
 
-// percentageExtractor extracts a percentage value from StatusJSON.
-type percentageExtractor func(data *status.StatusJSON) float64
+// percentageExtractor extracts a percentage value from status Data.
+type percentageExtractor func(data *status.Session) float64
 
 // percentageWidget is a generic widget that displays a formatted percentage.
 type percentageWidget struct {

--- a/internal/widget/context_percentage_usable.go
+++ b/internal/widget/context_percentage_usable.go
@@ -15,11 +15,11 @@ func (w *ContextPercentageUsableWidget) Render(item *config.WidgetItem, ctx Rend
 	if ctx.Data == nil {
 		return ""
 	}
-	length := status.GetContextLength(ctx.Data)
+	length := status.ContextLength(ctx.Data)
 	if length == 0 {
 		return ""
 	}
-	cfg := status.GetContextConfig(ctx.Data)
+	cfg := status.ContextConfig(ctx.Data)
 	if cfg.UsableTokens == 0 {
 		return ""
 	}

--- a/internal/widget/git_branch.go
+++ b/internal/widget/git_branch.go
@@ -10,7 +10,7 @@ type GitBranchWidget struct{}
 
 // Render returns the current git branch, optionally prefixed with a character.
 func (w *GitBranchWidget) Render(item *config.WidgetItem, _ RenderContext, _ *config.Settings) string {
-	branch := git.GetBranch()
+	branch := git.Branch()
 	if branch == "" {
 		return ""
 	}

--- a/internal/widget/git_changes.go
+++ b/internal/widget/git_changes.go
@@ -12,7 +12,7 @@ type GitChangesWidget struct{}
 
 // Render returns the uncommitted change count, or empty if there are none.
 func (w *GitChangesWidget) Render(_ *config.WidgetItem, _ RenderContext, _ *config.Settings) string {
-	n := git.GetChanges()
+	n := git.Changes()
 	if n == 0 {
 		return ""
 	}

--- a/internal/widget/git_worktree.go
+++ b/internal/widget/git_worktree.go
@@ -10,7 +10,7 @@ type GitWorktreeWidget struct{}
 
 // Render returns the worktree name if in a linked worktree, empty otherwise.
 func (w *GitWorktreeWidget) Render(_ *config.WidgetItem, _ RenderContext, _ *config.Settings) string {
-	return git.GetWorktree()
+	return git.Worktree()
 }
 
 // DefaultColor returns the default foreground color.

--- a/internal/widget/lines_changed.go
+++ b/internal/widget/lines_changed.go
@@ -12,7 +12,7 @@ type LinesChangedWidget struct{}
 
 // Render returns a "+N/-M" format from git diff --shortstat, or empty if clean.
 func (w *LinesChangedWidget) Render(_ *config.WidgetItem, _ RenderContext, _ *config.Settings) string {
-	stat := git.GetDiffStat()
+	stat := git.Diff()
 	if stat.Added == 0 && stat.Removed == 0 {
 		return ""
 	}
@@ -38,7 +38,7 @@ type LinesAddedWidget struct{}
 
 // Render returns "+N" from git diff, or empty if zero.
 func (w *LinesAddedWidget) Render(_ *config.WidgetItem, _ RenderContext, _ *config.Settings) string {
-	stat := git.GetDiffStat()
+	stat := git.Diff()
 	if stat.Added == 0 {
 		return ""
 	}
@@ -62,7 +62,7 @@ type LinesRemovedWidget struct{}
 
 // Render returns "-N" from git diff, or empty if zero.
 func (w *LinesRemovedWidget) Render(_ *config.WidgetItem, _ RenderContext, _ *config.Settings) string {
-	stat := git.GetDiffStat()
+	stat := git.Diff()
 	if stat.Removed == 0 {
 		return ""
 	}

--- a/internal/widget/string_field.go
+++ b/internal/widget/string_field.go
@@ -5,8 +5,8 @@ import (
 	"github.com/moond4rk/ccstatus/internal/status"
 )
 
-// stringFieldExtractor extracts a string value from StatusJSON.
-type stringFieldExtractor func(data *status.StatusJSON) string
+// stringFieldExtractor extracts a string value from status Data.
+type stringFieldExtractor func(data *status.Session) string
 
 // stringFieldWidget is a generic widget that displays a single string field.
 type stringFieldWidget struct {

--- a/internal/widget/tokens.go
+++ b/internal/widget/tokens.go
@@ -12,8 +12,8 @@ const (
 	defaultGreenColor = "green"
 )
 
-// tokenExtractor is a function that extracts a token count from StatusJSON.
-type tokenExtractor func(data *status.StatusJSON) (int, bool)
+// tokenExtractor is a function that extracts a token count from status Data.
+type tokenExtractor func(data *status.Session) (int, bool)
 
 // tokenWidget is a generic widget that displays a formatted token count.
 type tokenWidget struct {
@@ -38,49 +38,49 @@ func (w *tokenWidget) DisplayName() string    { return w.displayName }
 func (w *tokenWidget) Description() string    { return w.description }
 func (w *tokenWidget) SupportsRawValue() bool { return false }
 
-func extractInputTokens(data *status.StatusJSON) (int, bool) {
+func extractInputTokens(data *status.Session) (int, bool) {
 	if data.ContextWindow == nil || data.ContextWindow.TotalInputTokens == nil {
 		return 0, false
 	}
 	return *data.ContextWindow.TotalInputTokens, true
 }
 
-func extractOutputTokens(data *status.StatusJSON) (int, bool) {
+func extractOutputTokens(data *status.Session) (int, bool) {
 	if data.ContextWindow == nil || data.ContextWindow.TotalOutputTokens == nil {
 		return 0, false
 	}
 	return *data.ContextWindow.TotalOutputTokens, true
 }
 
-func extractCachedTokens(data *status.StatusJSON) (int, bool) {
+func extractCachedTokens(data *status.Session) (int, bool) {
 	if data.ContextWindow == nil || data.ContextWindow.CurrentUsage == nil {
 		return 0, false
 	}
 	return data.ContextWindow.CurrentUsage.CacheReadInputTokens, true
 }
 
-func extractCurrentInputTokens(data *status.StatusJSON) (int, bool) {
+func extractCurrentInputTokens(data *status.Session) (int, bool) {
 	if data.ContextWindow == nil || data.ContextWindow.CurrentUsage == nil {
 		return 0, false
 	}
 	return data.ContextWindow.CurrentUsage.InputTokens, true
 }
 
-func extractCurrentOutputTokens(data *status.StatusJSON) (int, bool) {
+func extractCurrentOutputTokens(data *status.Session) (int, bool) {
 	if data.ContextWindow == nil || data.ContextWindow.CurrentUsage == nil {
 		return 0, false
 	}
 	return data.ContextWindow.CurrentUsage.OutputTokens, true
 }
 
-func extractCacheCreationTokens(data *status.StatusJSON) (int, bool) {
+func extractCacheCreationTokens(data *status.Session) (int, bool) {
 	if data.ContextWindow == nil || data.ContextWindow.CurrentUsage == nil {
 		return 0, false
 	}
 	return data.ContextWindow.CurrentUsage.CacheCreationInputTokens, true
 }
 
-func extractTotalTokens(data *status.StatusJSON) (int, bool) {
+func extractTotalTokens(data *status.Session) (int, bool) {
 	if data.ContextWindow == nil {
 		return 0, false
 	}

--- a/internal/widget/widget.go
+++ b/internal/widget/widget.go
@@ -7,9 +7,9 @@ import (
 )
 
 // RenderContext carries runtime data available to all widgets during rendering.
-// Most token/context data comes directly from StatusJSON.ContextWindow (official API).
+// Most token/context data comes directly from Data.ContextWindow (official API).
 type RenderContext struct {
-	Data          *status.StatusJSON
+	Data          *status.Session
 	TerminalWidth int
 }
 
@@ -71,11 +71,11 @@ var registry = map[string]Widget{
 	// Context window
 	"context-length": &ContextLengthWidget{},
 	"context-percentage": &percentageWidget{
-		extract: status.GetContextPercentage, displayName: "Context %", description: "Context usage as percentage of max window",
+		extract: status.ContextPercentage, displayName: "Context %", description: "Context usage as percentage of max window",
 	},
 	"context-percentage-usable": &ContextPercentageUsableWidget{},
 	"remaining-percentage": &percentageWidget{
-		extract: status.GetRemainingPercentage, displayName: "Remaining %", description: "Remaining context window percentage",
+		extract: status.RemainingPercentage, displayName: "Remaining %", description: "Remaining context window percentage",
 	},
 
 	// Environment
@@ -93,7 +93,7 @@ var registry = map[string]Widget{
 	// Session info
 	"session-id": &SessionIDWidget{},
 	"output-style": &stringFieldWidget{
-		extract: func(data *status.StatusJSON) string {
+		extract: func(data *status.Session) string {
 			if data.OutputStyle == nil {
 				return ""
 			}
@@ -104,7 +104,7 @@ var registry = map[string]Widget{
 		description:  "Current output style name",
 	},
 	"vim-mode": &stringFieldWidget{
-		extract: func(data *status.StatusJSON) string {
+		extract: func(data *status.Session) string {
 			if data.Vim == nil {
 				return ""
 			}
@@ -115,7 +115,7 @@ var registry = map[string]Widget{
 		description:  "Current vim mode indicator",
 	},
 	"agent-name": &stringFieldWidget{
-		extract: func(data *status.StatusJSON) string {
+		extract: func(data *status.Session) string {
 			if data.Agent == nil {
 				return ""
 			}

--- a/internal/widget/widget_test.go
+++ b/internal/widget/widget_test.go
@@ -78,13 +78,13 @@ func TestModelWidget(t *testing.T) {
 	tests := []struct {
 		name     string
 		item     config.WidgetItem
-		data     *status.StatusJSON
+		data     *status.Session
 		expected string
 	}{
 		{
 			name: "display name",
 			item: config.WidgetItem{Type: "model"},
-			data: &status.StatusJSON{
+			data: &status.Session{
 				Model: status.ModelField{ID: "claude-sonnet-4-5", DisplayName: "Sonnet"},
 			},
 			expected: "Sonnet",
@@ -92,7 +92,7 @@ func TestModelWidget(t *testing.T) {
 		{
 			name: "raw value returns ID",
 			item: config.WidgetItem{Type: "model", RawValue: true},
-			data: &status.StatusJSON{
+			data: &status.Session{
 				Model: status.ModelField{ID: "claude-sonnet-4-5", DisplayName: "Sonnet"},
 			},
 			expected: "claude-sonnet-4-5",
@@ -100,7 +100,7 @@ func TestModelWidget(t *testing.T) {
 		{
 			name: "fallback to ID when no display name",
 			item: config.WidgetItem{Type: "model"},
-			data: &status.StatusJSON{
+			data: &status.Session{
 				Model: status.ModelField{ID: "custom-model"},
 			},
 			expected: "custom-model",
@@ -129,7 +129,7 @@ func TestVersionWidget(t *testing.T) {
 	settings := config.DefaultSettings()
 
 	t.Run("returns version", func(t *testing.T) {
-		ctx := RenderContext{Data: &status.StatusJSON{Version: "1.0.80"}}
+		ctx := RenderContext{Data: &status.Session{Version: "1.0.80"}}
 		item := config.WidgetItem{}
 		assert.Equal(t, "1.0.80", w.Render(&item, ctx, &settings))
 	})
@@ -200,7 +200,7 @@ func TestTokenWidgets(t *testing.T) {
 
 	t.Run("tokens-input formats input tokens", func(t *testing.T) {
 		w := Get("tokens-input")
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			ContextWindow: &status.ContextWindow{TotalInputTokens: intPtr(50_000)},
 		}}
 		assert.Equal(t, "50.0k", w.Render(&item, ctx, &settings))
@@ -209,7 +209,7 @@ func TestTokenWidgets(t *testing.T) {
 
 	t.Run("tokens-input nil context window", func(t *testing.T) {
 		w := Get("tokens-input")
-		ctx := RenderContext{Data: &status.StatusJSON{}}
+		ctx := RenderContext{Data: &status.Session{}}
 		assert.Empty(t, w.Render(&item, ctx, &settings))
 	})
 
@@ -221,7 +221,7 @@ func TestTokenWidgets(t *testing.T) {
 
 	t.Run("tokens-output formats output tokens", func(t *testing.T) {
 		w := Get("tokens-output")
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			ContextWindow: &status.ContextWindow{TotalOutputTokens: intPtr(1_200_000)},
 		}}
 		assert.Equal(t, "1.2M", w.Render(&item, ctx, &settings))
@@ -229,13 +229,13 @@ func TestTokenWidgets(t *testing.T) {
 
 	t.Run("tokens-output nil returns empty", func(t *testing.T) {
 		w := Get("tokens-output")
-		ctx := RenderContext{Data: &status.StatusJSON{}}
+		ctx := RenderContext{Data: &status.Session{}}
 		assert.Empty(t, w.Render(&item, ctx, &settings))
 	})
 
 	t.Run("tokens-cached formats cached tokens", func(t *testing.T) {
 		w := Get("tokens-cached")
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			ContextWindow: &status.ContextWindow{
 				CurrentUsage: &status.CurrentUsage{CacheReadInputTokens: 8000},
 			},
@@ -245,7 +245,7 @@ func TestTokenWidgets(t *testing.T) {
 
 	t.Run("tokens-cached zero returns empty", func(t *testing.T) {
 		w := Get("tokens-cached")
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			ContextWindow: &status.ContextWindow{
 				CurrentUsage: &status.CurrentUsage{CacheReadInputTokens: 0},
 			},
@@ -255,7 +255,7 @@ func TestTokenWidgets(t *testing.T) {
 
 	t.Run("tokens-cached nil current usage", func(t *testing.T) {
 		w := Get("tokens-cached")
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			ContextWindow: &status.ContextWindow{},
 		}}
 		assert.Empty(t, w.Render(&item, ctx, &settings))
@@ -263,7 +263,7 @@ func TestTokenWidgets(t *testing.T) {
 
 	t.Run("tokens-total sums input and output", func(t *testing.T) {
 		w := Get("tokens-total")
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			ContextWindow: &status.ContextWindow{
 				TotalInputTokens:  intPtr(30_000),
 				TotalOutputTokens: intPtr(20_000),
@@ -274,7 +274,7 @@ func TestTokenWidgets(t *testing.T) {
 
 	t.Run("tokens-total input only", func(t *testing.T) {
 		w := Get("tokens-total")
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			ContextWindow: &status.ContextWindow{
 				TotalInputTokens: intPtr(500),
 			},
@@ -284,7 +284,7 @@ func TestTokenWidgets(t *testing.T) {
 
 	t.Run("tokens-total both zero returns empty", func(t *testing.T) {
 		w := Get("tokens-total")
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			ContextWindow: &status.ContextWindow{
 				TotalInputTokens:  intPtr(0),
 				TotalOutputTokens: intPtr(0),
@@ -300,7 +300,7 @@ func TestContextLengthWidget(t *testing.T) {
 	item := config.WidgetItem{}
 
 	t.Run("formats context length", func(t *testing.T) {
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			ContextWindow: &status.ContextWindow{
 				CurrentUsage: &status.CurrentUsage{
 					InputTokens:              40_000,
@@ -313,7 +313,7 @@ func TestContextLengthWidget(t *testing.T) {
 	})
 
 	t.Run("zero returns empty", func(t *testing.T) {
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			ContextWindow: &status.ContextWindow{
 				CurrentUsage: &status.CurrentUsage{},
 			},
@@ -335,7 +335,7 @@ func TestContextPercentageWidget(t *testing.T) {
 
 	t.Run("formatted percentage", func(t *testing.T) {
 		item := config.WidgetItem{}
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			ContextWindow: &status.ContextWindow{UsedPercentage: floatPtr(25.7)},
 		}}
 		assert.Equal(t, "26%", w.Render(&item, ctx, &settings))
@@ -343,7 +343,7 @@ func TestContextPercentageWidget(t *testing.T) {
 
 	t.Run("raw value omits percent sign", func(t *testing.T) {
 		item := config.WidgetItem{RawValue: true}
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			ContextWindow: &status.ContextWindow{UsedPercentage: floatPtr(25.7)},
 		}}
 		assert.Equal(t, "25.7", w.Render(&item, ctx, &settings))
@@ -351,7 +351,7 @@ func TestContextPercentageWidget(t *testing.T) {
 
 	t.Run("zero returns empty", func(t *testing.T) {
 		item := config.WidgetItem{}
-		ctx := RenderContext{Data: &status.StatusJSON{}}
+		ctx := RenderContext{Data: &status.Session{}}
 		assert.Empty(t, w.Render(&item, ctx, &settings))
 	})
 
@@ -364,7 +364,7 @@ func TestContextPercentageUsableWidget(t *testing.T) {
 
 	t.Run("percentage of usable window", func(t *testing.T) {
 		item := config.WidgetItem{}
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			ContextWindow: &status.ContextWindow{
 				ContextWindowSize: intPtr(200_000),
 				CurrentUsage: &status.CurrentUsage{
@@ -378,7 +378,7 @@ func TestContextPercentageUsableWidget(t *testing.T) {
 
 	t.Run("raw value", func(t *testing.T) {
 		item := config.WidgetItem{RawValue: true}
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			ContextWindow: &status.ContextWindow{
 				ContextWindowSize: intPtr(200_000),
 				CurrentUsage: &status.CurrentUsage{
@@ -391,7 +391,7 @@ func TestContextPercentageUsableWidget(t *testing.T) {
 
 	t.Run("capped at 100", func(t *testing.T) {
 		item := config.WidgetItem{}
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			ContextWindow: &status.ContextWindow{
 				ContextWindowSize: intPtr(200_000),
 				CurrentUsage: &status.CurrentUsage{
@@ -429,7 +429,7 @@ func TestCurrentDirWidget(t *testing.T) {
 
 	t.Run("base dir name", func(t *testing.T) {
 		item := config.WidgetItem{}
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			Workspace: &status.Workspace{CurrentDir: "/home/user/projects/myapp"},
 		}}
 		assert.Equal(t, "myapp", w.Render(&item, ctx, &settings))
@@ -437,7 +437,7 @@ func TestCurrentDirWidget(t *testing.T) {
 
 	t.Run("raw value returns path outside home", func(t *testing.T) {
 		item := config.WidgetItem{RawValue: true}
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			Workspace: &status.Workspace{CurrentDir: "/opt/projects/myapp"},
 		}}
 		assert.Equal(t, "/opt/projects/myapp", w.Render(&item, ctx, &settings))
@@ -446,7 +446,7 @@ func TestCurrentDirWidget(t *testing.T) {
 	t.Run("raw value shortens home dir", func(t *testing.T) {
 		item := config.WidgetItem{RawValue: true}
 		home, _ := os.UserHomeDir()
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			Workspace: &status.Workspace{CurrentDir: home + "/projects/myapp"},
 		}}
 		assert.Equal(t, "~/projects/myapp", w.Render(&item, ctx, &settings))
@@ -454,13 +454,13 @@ func TestCurrentDirWidget(t *testing.T) {
 
 	t.Run("falls back to cwd", func(t *testing.T) {
 		item := config.WidgetItem{}
-		ctx := RenderContext{Data: &status.StatusJSON{Cwd: "/tmp/test"}}
+		ctx := RenderContext{Data: &status.Session{Cwd: "/tmp/test"}}
 		assert.Equal(t, "test", w.Render(&item, ctx, &settings))
 	})
 
 	t.Run("nil data returns empty", func(t *testing.T) {
 		item := config.WidgetItem{}
-		ctx := RenderContext{Data: &status.StatusJSON{}}
+		ctx := RenderContext{Data: &status.Session{}}
 		assert.Empty(t, w.Render(&item, ctx, &settings))
 	})
 
@@ -474,7 +474,7 @@ func TestSessionCostWidget(t *testing.T) {
 
 	t.Run("formats cost with dollar sign", func(t *testing.T) {
 		item := config.WidgetItem{}
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			Cost: &status.CostInfo{TotalCostUSD: floatPtr(1.23)},
 		}}
 		assert.Equal(t, "$1.23", w.Render(&item, ctx, &settings))
@@ -482,7 +482,7 @@ func TestSessionCostWidget(t *testing.T) {
 
 	t.Run("small cost uses 4 decimals", func(t *testing.T) {
 		item := config.WidgetItem{}
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			Cost: &status.CostInfo{TotalCostUSD: floatPtr(0.0012)},
 		}}
 		assert.Equal(t, "$0.0012", w.Render(&item, ctx, &settings))
@@ -490,7 +490,7 @@ func TestSessionCostWidget(t *testing.T) {
 
 	t.Run("raw value omits dollar sign", func(t *testing.T) {
 		item := config.WidgetItem{RawValue: true}
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			Cost: &status.CostInfo{TotalCostUSD: floatPtr(1.23)},
 		}}
 		assert.Equal(t, "1.2300", w.Render(&item, ctx, &settings))
@@ -498,7 +498,7 @@ func TestSessionCostWidget(t *testing.T) {
 
 	t.Run("nil cost returns empty", func(t *testing.T) {
 		item := config.WidgetItem{}
-		ctx := RenderContext{Data: &status.StatusJSON{}}
+		ctx := RenderContext{Data: &status.Session{}}
 		assert.Empty(t, w.Render(&item, ctx, &settings))
 	})
 
@@ -524,7 +524,7 @@ func TestSessionClockWidget(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			item := config.WidgetItem{}
-			ctx := RenderContext{Data: &status.StatusJSON{
+			ctx := RenderContext{Data: &status.Session{
 				Cost: &status.CostInfo{TotalDurationMS: floatPtr(tt.ms)},
 			}}
 			assert.Equal(t, tt.expected, w.Render(&item, ctx, &settings))
@@ -533,13 +533,13 @@ func TestSessionClockWidget(t *testing.T) {
 
 	t.Run("nil cost returns empty", func(t *testing.T) {
 		item := config.WidgetItem{}
-		ctx := RenderContext{Data: &status.StatusJSON{}}
+		ctx := RenderContext{Data: &status.Session{}}
 		assert.Empty(t, w.Render(&item, ctx, &settings))
 	})
 
 	t.Run("raw value returns ms", func(t *testing.T) {
 		item := config.WidgetItem{RawValue: true}
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			Cost: &status.CostInfo{TotalDurationMS: floatPtr(300_000)},
 		}}
 		assert.Equal(t, "300000", w.Render(&item, ctx, &settings))
@@ -557,7 +557,7 @@ func TestLinesChangedWidget(t *testing.T) {
 		// Verify output is either empty or matches +N/-M format.
 		settings := config.DefaultSettings()
 		item := config.WidgetItem{}
-		ctx := RenderContext{Data: &status.StatusJSON{}}
+		ctx := RenderContext{Data: &status.Session{}}
 		result := w.Render(&item, ctx, &settings)
 		if result != "" {
 			assert.Regexp(t, `^\+\d+/-\d+$`, result)
@@ -575,7 +575,7 @@ func TestLinesAddedWidget(t *testing.T) {
 	t.Run("returns git diff format or empty", func(t *testing.T) {
 		settings := config.DefaultSettings()
 		item := config.WidgetItem{}
-		ctx := RenderContext{Data: &status.StatusJSON{}}
+		ctx := RenderContext{Data: &status.Session{}}
 		result := w.Render(&item, ctx, &settings)
 		if result != "" {
 			assert.Regexp(t, `^\+\d+$`, result)
@@ -591,7 +591,7 @@ func TestLinesRemovedWidget(t *testing.T) {
 	t.Run("returns git diff format or empty", func(t *testing.T) {
 		settings := config.DefaultSettings()
 		item := config.WidgetItem{}
-		ctx := RenderContext{Data: &status.StatusJSON{}}
+		ctx := RenderContext{Data: &status.Session{}}
 		result := w.Render(&item, ctx, &settings)
 		if result != "" {
 			assert.Regexp(t, `^-\d+$`, result)
@@ -640,7 +640,7 @@ func TestRemainingPercentageWidget(t *testing.T) {
 
 	t.Run("formatted percentage", func(t *testing.T) {
 		item := config.WidgetItem{}
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			ContextWindow: &status.ContextWindow{RemainingPercentage: floatPtr(74.3)},
 		}}
 		assert.Equal(t, "74%", w.Render(&item, ctx, &settings))
@@ -648,7 +648,7 @@ func TestRemainingPercentageWidget(t *testing.T) {
 
 	t.Run("raw value omits percent sign", func(t *testing.T) {
 		item := config.WidgetItem{RawValue: true}
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			ContextWindow: &status.ContextWindow{RemainingPercentage: floatPtr(74.3)},
 		}}
 		assert.Equal(t, "74.3", w.Render(&item, ctx, &settings))
@@ -656,7 +656,7 @@ func TestRemainingPercentageWidget(t *testing.T) {
 
 	t.Run("zero returns empty", func(t *testing.T) {
 		item := config.WidgetItem{}
-		ctx := RenderContext{Data: &status.StatusJSON{}}
+		ctx := RenderContext{Data: &status.Session{}}
 		assert.Empty(t, w.Render(&item, ctx, &settings))
 	})
 
@@ -687,7 +687,7 @@ func TestAPIDurationWidget(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			item := config.WidgetItem{}
-			ctx := RenderContext{Data: &status.StatusJSON{
+			ctx := RenderContext{Data: &status.Session{
 				Cost: &status.CostInfo{TotalAPIDurationMS: floatPtr(tt.ms)},
 			}}
 			assert.Equal(t, tt.expected, w.Render(&item, ctx, &settings))
@@ -696,7 +696,7 @@ func TestAPIDurationWidget(t *testing.T) {
 
 	t.Run("nil cost returns empty", func(t *testing.T) {
 		item := config.WidgetItem{}
-		ctx := RenderContext{Data: &status.StatusJSON{}}
+		ctx := RenderContext{Data: &status.Session{}}
 		assert.Empty(t, w.Render(&item, ctx, &settings))
 	})
 
@@ -708,7 +708,7 @@ func TestAPIDurationWidget(t *testing.T) {
 
 	t.Run("raw value returns ms", func(t *testing.T) {
 		item := config.WidgetItem{RawValue: true}
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			Cost: &status.CostInfo{TotalAPIDurationMS: floatPtr(2300)},
 		}}
 		assert.Equal(t, "2300", w.Render(&item, ctx, &settings))
@@ -724,7 +724,7 @@ func TestProjectDirWidget(t *testing.T) {
 
 	t.Run("base dir name", func(t *testing.T) {
 		item := config.WidgetItem{}
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			Workspace: &status.Workspace{ProjectDir: "/home/user/projects/myapp"},
 		}}
 		assert.Equal(t, "myapp", w.Render(&item, ctx, &settings))
@@ -732,7 +732,7 @@ func TestProjectDirWidget(t *testing.T) {
 
 	t.Run("raw value returns path outside home", func(t *testing.T) {
 		item := config.WidgetItem{RawValue: true}
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			Workspace: &status.Workspace{ProjectDir: "/opt/projects/myapp"},
 		}}
 		assert.Equal(t, "/opt/projects/myapp", w.Render(&item, ctx, &settings))
@@ -741,7 +741,7 @@ func TestProjectDirWidget(t *testing.T) {
 	t.Run("raw value shortens home dir", func(t *testing.T) {
 		item := config.WidgetItem{RawValue: true}
 		home, _ := os.UserHomeDir()
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			Workspace: &status.Workspace{ProjectDir: home + "/projects/myapp"},
 		}}
 		assert.Equal(t, "~/projects/myapp", w.Render(&item, ctx, &settings))
@@ -749,7 +749,7 @@ func TestProjectDirWidget(t *testing.T) {
 
 	t.Run("empty project dir returns empty", func(t *testing.T) {
 		item := config.WidgetItem{}
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			Workspace: &status.Workspace{},
 		}}
 		assert.Empty(t, w.Render(&item, ctx, &settings))
@@ -757,7 +757,7 @@ func TestProjectDirWidget(t *testing.T) {
 
 	t.Run("nil workspace returns empty", func(t *testing.T) {
 		item := config.WidgetItem{}
-		ctx := RenderContext{Data: &status.StatusJSON{}}
+		ctx := RenderContext{Data: &status.Session{}}
 		assert.Empty(t, w.Render(&item, ctx, &settings))
 	})
 
@@ -777,7 +777,7 @@ func TestTranscriptPathWidget(t *testing.T) {
 
 	t.Run("base file name", func(t *testing.T) {
 		item := config.WidgetItem{}
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			TranscriptPath: "/tmp/session/transcript.jsonl",
 		}}
 		assert.Equal(t, "transcript.jsonl", w.Render(&item, ctx, &settings))
@@ -785,7 +785,7 @@ func TestTranscriptPathWidget(t *testing.T) {
 
 	t.Run("raw value returns path outside home", func(t *testing.T) {
 		item := config.WidgetItem{RawValue: true}
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			TranscriptPath: "/tmp/session/transcript.jsonl",
 		}}
 		assert.Equal(t, "/tmp/session/transcript.jsonl", w.Render(&item, ctx, &settings))
@@ -794,7 +794,7 @@ func TestTranscriptPathWidget(t *testing.T) {
 	t.Run("raw value shortens home dir", func(t *testing.T) {
 		item := config.WidgetItem{RawValue: true}
 		home, _ := os.UserHomeDir()
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			TranscriptPath: home + "/.claude/transcript.jsonl",
 		}}
 		assert.Equal(t, "~/.claude/transcript.jsonl", w.Render(&item, ctx, &settings))
@@ -802,7 +802,7 @@ func TestTranscriptPathWidget(t *testing.T) {
 
 	t.Run("empty path returns empty", func(t *testing.T) {
 		item := config.WidgetItem{}
-		ctx := RenderContext{Data: &status.StatusJSON{}}
+		ctx := RenderContext{Data: &status.Session{}}
 		assert.Empty(t, w.Render(&item, ctx, &settings))
 	})
 
@@ -822,7 +822,7 @@ func TestCurrentUsageTokenWidgets(t *testing.T) {
 
 	t.Run("current-usage-input formats tokens", func(t *testing.T) {
 		w := Get("current-usage-input")
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			ContextWindow: &status.ContextWindow{
 				CurrentUsage: &status.CurrentUsage{InputTokens: 8500},
 			},
@@ -832,7 +832,7 @@ func TestCurrentUsageTokenWidgets(t *testing.T) {
 
 	t.Run("current-usage-input nil current usage", func(t *testing.T) {
 		w := Get("current-usage-input")
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			ContextWindow: &status.ContextWindow{},
 		}}
 		assert.Empty(t, w.Render(&item, ctx, &settings))
@@ -846,7 +846,7 @@ func TestCurrentUsageTokenWidgets(t *testing.T) {
 
 	t.Run("current-usage-output formats tokens", func(t *testing.T) {
 		w := Get("current-usage-output")
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			ContextWindow: &status.ContextWindow{
 				CurrentUsage: &status.CurrentUsage{OutputTokens: 1200},
 			},
@@ -856,7 +856,7 @@ func TestCurrentUsageTokenWidgets(t *testing.T) {
 
 	t.Run("current-usage-output zero returns empty", func(t *testing.T) {
 		w := Get("current-usage-output")
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			ContextWindow: &status.ContextWindow{
 				CurrentUsage: &status.CurrentUsage{OutputTokens: 0},
 			},
@@ -866,7 +866,7 @@ func TestCurrentUsageTokenWidgets(t *testing.T) {
 
 	t.Run("cache-creation formats tokens", func(t *testing.T) {
 		w := Get("cache-creation")
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			ContextWindow: &status.ContextWindow{
 				CurrentUsage: &status.CurrentUsage{CacheCreationInputTokens: 5000},
 			},
@@ -876,7 +876,7 @@ func TestCurrentUsageTokenWidgets(t *testing.T) {
 
 	t.Run("cache-creation zero returns empty", func(t *testing.T) {
 		w := Get("cache-creation")
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			ContextWindow: &status.ContextWindow{
 				CurrentUsage: &status.CurrentUsage{CacheCreationInputTokens: 0},
 			},
@@ -886,7 +886,7 @@ func TestCurrentUsageTokenWidgets(t *testing.T) {
 
 	t.Run("cache-creation nil context window", func(t *testing.T) {
 		w := Get("cache-creation")
-		ctx := RenderContext{Data: &status.StatusJSON{}}
+		ctx := RenderContext{Data: &status.Session{}}
 		assert.Empty(t, w.Render(&item, ctx, &settings))
 	})
 }
@@ -914,7 +914,7 @@ func TestOutputStyleWidget(t *testing.T) {
 
 	t.Run("returns style name", func(t *testing.T) {
 		item := config.WidgetItem{}
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			OutputStyle: &status.OutputStyle{Name: "text"},
 		}}
 		assert.Equal(t, "text", w.Render(&item, ctx, &settings))
@@ -922,7 +922,7 @@ func TestOutputStyleWidget(t *testing.T) {
 
 	t.Run("stream-json style", func(t *testing.T) {
 		item := config.WidgetItem{}
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			OutputStyle: &status.OutputStyle{Name: "stream-json"},
 		}}
 		assert.Equal(t, "stream-json", w.Render(&item, ctx, &settings))
@@ -930,7 +930,7 @@ func TestOutputStyleWidget(t *testing.T) {
 
 	t.Run("nil output style returns empty", func(t *testing.T) {
 		item := config.WidgetItem{}
-		ctx := RenderContext{Data: &status.StatusJSON{}}
+		ctx := RenderContext{Data: &status.Session{}}
 		assert.Empty(t, w.Render(&item, ctx, &settings))
 	})
 
@@ -950,7 +950,7 @@ func TestSessionIDWidget(t *testing.T) {
 
 	t.Run("truncated by default", func(t *testing.T) {
 		item := config.WidgetItem{}
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			SessionID: "abc12345-6789-0abc-def0-123456789abc",
 		}}
 		assert.Equal(t, "abc12345", w.Render(&item, ctx, &settings))
@@ -958,7 +958,7 @@ func TestSessionIDWidget(t *testing.T) {
 
 	t.Run("raw value returns full UUID", func(t *testing.T) {
 		item := config.WidgetItem{RawValue: true}
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			SessionID: "abc12345-6789-0abc-def0-123456789abc",
 		}}
 		assert.Equal(t, "abc12345-6789-0abc-def0-123456789abc", w.Render(&item, ctx, &settings))
@@ -966,7 +966,7 @@ func TestSessionIDWidget(t *testing.T) {
 
 	t.Run("short ID not truncated", func(t *testing.T) {
 		item := config.WidgetItem{}
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			SessionID: "abc",
 		}}
 		assert.Equal(t, "abc", w.Render(&item, ctx, &settings))
@@ -974,7 +974,7 @@ func TestSessionIDWidget(t *testing.T) {
 
 	t.Run("empty session ID returns empty", func(t *testing.T) {
 		item := config.WidgetItem{}
-		ctx := RenderContext{Data: &status.StatusJSON{}}
+		ctx := RenderContext{Data: &status.Session{}}
 		assert.Empty(t, w.Render(&item, ctx, &settings))
 	})
 
@@ -1018,21 +1018,21 @@ func TestVimModeWidget(t *testing.T) {
 	item := config.WidgetItem{}
 
 	t.Run("returns NORMAL mode", func(t *testing.T) {
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			Vim: &status.VimInfo{Mode: "NORMAL"},
 		}}
 		assert.Equal(t, "NORMAL", w.Render(&item, ctx, &settings))
 	})
 
 	t.Run("returns INSERT mode", func(t *testing.T) {
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			Vim: &status.VimInfo{Mode: "INSERT"},
 		}}
 		assert.Equal(t, "INSERT", w.Render(&item, ctx, &settings))
 	})
 
 	t.Run("nil vim returns empty", func(t *testing.T) {
-		ctx := RenderContext{Data: &status.StatusJSON{}}
+		ctx := RenderContext{Data: &status.Session{}}
 		assert.Empty(t, w.Render(&item, ctx, &settings))
 	})
 
@@ -1051,14 +1051,14 @@ func TestAgentNameWidget(t *testing.T) {
 	item := config.WidgetItem{}
 
 	t.Run("returns agent name", func(t *testing.T) {
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			Agent: &status.AgentInfo{Name: "security-reviewer"},
 		}}
 		assert.Equal(t, "security-reviewer", w.Render(&item, ctx, &settings))
 	})
 
 	t.Run("nil agent returns empty", func(t *testing.T) {
-		ctx := RenderContext{Data: &status.StatusJSON{}}
+		ctx := RenderContext{Data: &status.Session{}}
 		assert.Empty(t, w.Render(&item, ctx, &settings))
 	})
 
@@ -1077,21 +1077,21 @@ func TestExceeds200KWidget(t *testing.T) {
 	item := config.WidgetItem{}
 
 	t.Run("true returns warning", func(t *testing.T) {
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			Exceeds200K: boolPtr(true),
 		}}
 		assert.Equal(t, ">200k", w.Render(&item, ctx, &settings))
 	})
 
 	t.Run("false returns empty", func(t *testing.T) {
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			Exceeds200K: boolPtr(false),
 		}}
 		assert.Empty(t, w.Render(&item, ctx, &settings))
 	})
 
 	t.Run("nil returns empty", func(t *testing.T) {
-		ctx := RenderContext{Data: &status.StatusJSON{}}
+		ctx := RenderContext{Data: &status.Session{}}
 		assert.Empty(t, w.Render(&item, ctx, &settings))
 	})
 
@@ -1110,25 +1110,25 @@ func TestCustomCommandWidget(t *testing.T) {
 
 	t.Run("executes echo command", func(t *testing.T) {
 		item := config.WidgetItem{CommandPath: "echo hello"}
-		ctx := RenderContext{Data: &status.StatusJSON{}}
+		ctx := RenderContext{Data: &status.Session{}}
 		assert.Equal(t, "hello", w.Render(&item, ctx, &settings))
 	})
 
 	t.Run("takes first line only", func(t *testing.T) {
 		item := config.WidgetItem{CommandPath: "printf 'line1\nline2'"}
-		ctx := RenderContext{Data: &status.StatusJSON{}}
+		ctx := RenderContext{Data: &status.Session{}}
 		assert.Equal(t, "line1", w.Render(&item, ctx, &settings))
 	})
 
 	t.Run("applies maxWidth", func(t *testing.T) {
 		item := config.WidgetItem{CommandPath: "echo longstring", MaxWidth: 4}
-		ctx := RenderContext{Data: &status.StatusJSON{}}
+		ctx := RenderContext{Data: &status.Session{}}
 		assert.Equal(t, "long", w.Render(&item, ctx, &settings))
 	})
 
 	t.Run("strips ANSI by default", func(t *testing.T) {
 		item := config.WidgetItem{CommandPath: `printf '\033[32mgreen\033[0m'`}
-		ctx := RenderContext{Data: &status.StatusJSON{}}
+		ctx := RenderContext{Data: &status.Session{}}
 		assert.Equal(t, "green", w.Render(&item, ctx, &settings))
 	})
 
@@ -1137,25 +1137,25 @@ func TestCustomCommandWidget(t *testing.T) {
 			CommandPath:    `printf '\033[32mgreen\033[0m'`,
 			PreserveColors: true,
 		}
-		ctx := RenderContext{Data: &status.StatusJSON{}}
+		ctx := RenderContext{Data: &status.Session{}}
 		assert.Contains(t, w.Render(&item, ctx, &settings), "green")
 	})
 
 	t.Run("empty commandPath returns empty", func(t *testing.T) {
 		item := config.WidgetItem{}
-		ctx := RenderContext{Data: &status.StatusJSON{}}
+		ctx := RenderContext{Data: &status.Session{}}
 		assert.Empty(t, w.Render(&item, ctx, &settings))
 	})
 
 	t.Run("failing command returns empty", func(t *testing.T) {
 		item := config.WidgetItem{CommandPath: "false"}
-		ctx := RenderContext{Data: &status.StatusJSON{}}
+		ctx := RenderContext{Data: &status.Session{}}
 		assert.Empty(t, w.Render(&item, ctx, &settings))
 	})
 
 	t.Run("pipes JSON to stdin", func(t *testing.T) {
 		item := config.WidgetItem{CommandPath: "cat | jq -r .version 2>/dev/null || echo fallback"}
-		ctx := RenderContext{Data: &status.StatusJSON{Version: "1.0.80"}}
+		ctx := RenderContext{Data: &status.Session{Version: "1.0.80"}}
 		result := w.Render(&item, ctx, &settings)
 		// jq may not be installed; accept either the parsed value or fallback.
 		assert.True(t, result == "1.0.80" || result == "fallback",
@@ -1172,7 +1172,7 @@ func TestBlockTimerWidget(t *testing.T) {
 
 	t.Run("time mode from duration_ms", func(t *testing.T) {
 		item := config.WidgetItem{}
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			Cost: &status.CostInfo{TotalDurationMS: floatPtr(5_400_000)}, // 1h30m
 		}}
 		assert.Equal(t, "1h30m/5h", w.Render(&item, ctx, &settings))
@@ -1180,7 +1180,7 @@ func TestBlockTimerWidget(t *testing.T) {
 
 	t.Run("time mode less than a minute", func(t *testing.T) {
 		item := config.WidgetItem{}
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			Cost: &status.CostInfo{TotalDurationMS: floatPtr(30_000)},
 		}}
 		assert.Equal(t, "<1m/5h", w.Render(&item, ctx, &settings))
@@ -1188,7 +1188,7 @@ func TestBlockTimerWidget(t *testing.T) {
 
 	t.Run("time mode hours only", func(t *testing.T) {
 		item := config.WidgetItem{}
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			Cost: &status.CostInfo{TotalDurationMS: floatPtr(7_200_000)}, // 2h
 		}}
 		assert.Equal(t, "2h/5h", w.Render(&item, ctx, &settings))
@@ -1196,7 +1196,7 @@ func TestBlockTimerWidget(t *testing.T) {
 
 	t.Run("clamped at 5h", func(t *testing.T) {
 		item := config.WidgetItem{}
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			Cost: &status.CostInfo{TotalDurationMS: floatPtr(20_000_000)}, // >5h
 		}}
 		assert.Equal(t, "5h/5h", w.Render(&item, ctx, &settings))
@@ -1204,7 +1204,7 @@ func TestBlockTimerWidget(t *testing.T) {
 
 	t.Run("percentage mode", func(t *testing.T) {
 		item := config.WidgetItem{Metadata: map[string]string{"display": "percentage"}}
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			Cost: &status.CostInfo{TotalDurationMS: floatPtr(9_000_000)}, // 2.5h = 50%
 		}}
 		assert.Equal(t, "50%", w.Render(&item, ctx, &settings))
@@ -1212,7 +1212,7 @@ func TestBlockTimerWidget(t *testing.T) {
 
 	t.Run("progress mode", func(t *testing.T) {
 		item := config.WidgetItem{Metadata: map[string]string{"display": "progress"}}
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			Cost: &status.CostInfo{TotalDurationMS: floatPtr(9_000_000)}, // 50%
 		}}
 		result := w.Render(&item, ctx, &settings)
@@ -1223,7 +1223,7 @@ func TestBlockTimerWidget(t *testing.T) {
 
 	t.Run("nil cost returns empty", func(t *testing.T) {
 		item := config.WidgetItem{}
-		ctx := RenderContext{Data: &status.StatusJSON{}}
+		ctx := RenderContext{Data: &status.Session{}}
 		assert.Empty(t, w.Render(&item, ctx, &settings))
 	})
 
@@ -1246,7 +1246,7 @@ func TestBlockTimerWidget(t *testing.T) {
 		tmpFile.Close()
 
 		item := config.WidgetItem{}
-		ctx := RenderContext{Data: &status.StatusJSON{
+		ctx := RenderContext{Data: &status.Session{
 			TranscriptPath: tmpFile.Name(),
 		}}
 		result := w.Render(&item, ctx, &settings)


### PR DESCRIPTION
## Summary

- **Remove `Get` prefix** from 10 functions across `status`, `git`, `terminal`, and `jsonl` packages (e.g. `GetBranch` -> `Branch`, `GetContextPercentage` -> `ContextPercentage`)
- **Eliminate package name stuttering** in `config` and `status` packages (`config.ConfigDir` -> `config.Dir`, `status.StatusJSON` -> `status.Session`)
- **Replace generic type name** `Data` with domain-specific `Session` in `status` package
- **Rename struct** `ContextConfig` -> `WindowLimits` to avoid collision with the `ContextConfig()` function after `Get` prefix removal
- **Fix mixed receivers** on `ModelField`: align `MarshalJSON` to pointer receiver to match `UnmarshalJSON`

29 files changed, mechanical rename with zero logic changes.

## Rename Map

| Package | Before | After | Reason |
|---------|--------|-------|--------|
| `status` | `StatusJSON` | `Session` | stuttering + generic |
| `status` | `ContextConfig` (struct) | `WindowLimits` | avoid collision |
| `status` | `GetContextConfig()` | `ContextConfig()` | remove Get |
| `status` | `GetContextPercentage()` | `ContextPercentage()` | remove Get |
| `status` | `GetRemainingPercentage()` | `RemainingPercentage()` | remove Get |
| `status` | `GetContextLength()` | `ContextLength()` | remove Get |
| `config` | `ConfigDir()` | `Dir()` | stuttering |
| `config` | `ConfigPath()` | `Path()` | stuttering |
| `git` | `GetBranch()` | `Branch()` | remove Get |
| `git` | `GetChanges()` | `Changes()` | remove Get |
| `git` | `GetDiffStat()` | `Diff()` | remove Get |
| `git` | `GetWorktree()` | `Worktree()` | remove Get |
| `terminal` | `GetWidth()` | `Width()` | remove Get |
| `jsonl` | `GetSessionStart()` | `SessionStart()` | remove Get |

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages)
- [x] `golangci-lint run` reports 0 issues