### PR TITLE
refactor: update terminal width detection logic

### DIFF
--- a/cmd/ccstatus/main.go
+++ b/cmd/ccstatus/main.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime/debug"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -16,6 +18,47 @@ import (
 )
 
 var version = "dev"
+
+// versionString returns a human-readable version string.
+// For tagged releases (set via ldflags), it returns the tag version.
+// For dev builds (go install), it appends VCS commit and date from build info.
+func versionString() string {
+	if version != "dev" {
+		return version
+	}
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return version
+	}
+	var revision, timeVal string
+	var modified bool
+	for _, s := range info.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			revision = s.Value
+		case "vcs.time":
+			timeVal = s.Value
+		case "vcs.modified":
+			modified = s.Value == "true"
+		}
+	}
+	if revision == "" {
+		return version
+	}
+	// Shorten commit hash to 7 characters.
+	if len(revision) > 7 {
+		revision = revision[:7]
+	}
+	// Extract date portion from RFC3339 timestamp.
+	if idx := strings.IndexByte(timeVal, 'T'); idx > 0 {
+		timeVal = timeVal[:idx]
+	}
+	v := fmt.Sprintf("dev (%s %s)", revision, timeVal)
+	if modified {
+		v += " dirty"
+	}
+	return v
+}
 
 func main() {
 	rootCmd := newRootCmd()
@@ -35,7 +78,7 @@ func newRootCmd() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	cmd.Version = version
+	cmd.Version = versionString()
 	cmd.AddCommand(
 		newInitCmd(),
 		newValidateCmd(),
@@ -68,12 +111,19 @@ func runStatusLine(_ *cobra.Command, _ []string) error {
 		TerminalWidth: terminal.Width(),
 	}
 
+	// Buffer all lines and write atomically to avoid partial reads
+	// when Claude Code reads from the pipe during rapid re-invocations.
+	var buf strings.Builder
 	for _, line := range settings.Lines {
 		rendered := render.RenderLine(line, &settings, ctx)
 		output := render.PostProcess(rendered)
 		if output != "" {
-			fmt.Println(output)
+			buf.WriteString(output)
+			buf.WriteByte('\n')
 		}
+	}
+	if buf.Len() > 0 {
+		fmt.Print(buf.String())
 	}
 	return nil
 }

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -12,17 +12,40 @@ import (
 const defaultWidth = 80
 
 // Width returns the terminal width in columns.
-// It tries term.GetSize first, then falls back to the COLUMNS environment
-// variable, and finally returns defaultWidth (80) if both fail.
+// Detection order: stdout fd, stderr fd, /dev/tty, COLUMNS env, default 80.
+// When running as a piped subprocess (e.g. Claude Code status line command),
+// stdout/stderr are pipes, so /dev/tty is typically the first successful source.
 func Width() int {
-	width, _, err := term.GetSize(int(os.Stdout.Fd()))
-	if err == nil && width > 0 {
-		return width
+	// Try stdout and stderr fds (works when at least one is a real terminal).
+	for _, f := range []*os.File{os.Stdout, os.Stderr} {
+		if w, _, err := term.GetSize(int(f.Fd())); err == nil && w > 0 {
+			return w
+		}
 	}
+	// Try the controlling terminal directly. This works even when all
+	// standard fds are pipes, as long as a controlling terminal exists.
+	if w := widthFromTTY(); w > 0 {
+		return w
+	}
+	// Fall back to the COLUMNS environment variable.
 	if cols := os.Getenv("COLUMNS"); cols != "" {
 		if n, err := strconv.Atoi(cols); err == nil && n > 0 {
 			return n
 		}
 	}
 	return defaultWidth
+}
+
+// widthFromTTY opens /dev/tty and queries its width.
+func widthFromTTY() int {
+	f, err := os.Open("/dev/tty")
+	if err != nil {
+		return 0
+	}
+	defer f.Close()
+	w, _, err := term.GetSize(int(f.Fd()))
+	if err != nil {
+		return 0
+	}
+	return w
 }


### PR DESCRIPTION
- Improve version handling in `main.go` for better readability
- Enhance output rendering by buffering to prevent partial reads
- Optimize terminal width detection in `terminal.go` for accurate results