### PR TITLE
fix: remove leading article from Homebrew description

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,7 +48,7 @@ release:
 brews:
   - name: ccstatus
     homepage: "https://github.com/moonD4rk/ccstatus"
-    description: "A customizable status line formatter for Claude Code CLI"
+    description: "Customizable status line formatter for Claude Code CLI"
     license: "Apache-2.0"
     directory: Formula
     skip_upload: auto


### PR DESCRIPTION
## Summary
- Remove leading article "A" from GoReleaser brew description to pass Homebrew lint (`brew audit --strict`)
- `"A customizable status line formatter..."` -> `"Customizable status line formatter..."`
- Fixes https://github.com/moonD4rk/homebrew-tap/actions/runs/22542573395/job/65299882075

## Test plan
- [ ] Next release should generate a Formula that passes `brew audit --strict` without description offense