### PR TITLE
feat: implement install/uninstall commands

### DIFF
--- a/cmd/ccstatus/cmd_install.go
+++ b/cmd/ccstatus/cmd_install.go
@@ -5,6 +5,8 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+
+	"github.com/moond4rk/ccstatus/internal/claude"
 )
 
 func newInstallCmd() *cobra.Command {
@@ -26,11 +28,19 @@ func newUninstallCmd() *cobra.Command {
 }
 
 func runInstall(_ *cobra.Command, _ []string) error {
-	fmt.Fprintln(os.Stderr, "Install not yet implemented")
+	path, err := claude.Install()
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "ccstatus installed successfully: %s\n", path)
 	return nil
 }
 
 func runUninstall(_ *cobra.Command, _ []string) error {
-	fmt.Fprintln(os.Stderr, "Uninstall not yet implemented")
+	path, err := claude.Uninstall()
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "ccstatus uninstalled successfully: %s\n", path)
 	return nil
 }

--- a/internal/claude/claude.go
+++ b/internal/claude/claude.go
@@ -1,0 +1,120 @@
+// Package claude provides integration with Claude Code's settings.json.
+package claude
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+const settingsFileName = "settings.json"
+
+// StatusLine is the configuration block written to Claude Code's settings.json.
+type StatusLine struct {
+	Type    string `json:"type"`
+	Command string `json:"command"`
+	Padding int    `json:"padding"`
+}
+
+// Dir returns the Claude Code configuration directory.
+// It respects the CLAUDE_CONFIG_DIR environment variable,
+// falling back to ~/.claude.
+func Dir() string {
+	if dir := os.Getenv("CLAUDE_CONFIG_DIR"); dir != "" {
+		return dir
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".claude")
+}
+
+// SettingsPath returns the full path to Claude Code's settings.json.
+func SettingsPath() string {
+	return filepath.Join(Dir(), settingsFileName)
+}
+
+// Install registers ccstatus in Claude Code's settings.json.
+// It preserves all existing fields and creates the file if it does not exist.
+// The path to the written settings file is returned.
+func Install() (string, error) {
+	path := SettingsPath()
+	settings, err := readSettings(path)
+	if err != nil {
+		return "", err
+	}
+
+	settings["statusLine"] = StatusLine{
+		Type:    "command",
+		Command: "ccstatus",
+		Padding: 0,
+	}
+
+	if err := writeSettings(path, settings); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+// Uninstall removes the ccstatus statusLine from Claude Code's settings.json.
+// It is a no-op if the file does not exist or statusLine is not present.
+// The path to the settings file is returned.
+func Uninstall() (string, error) {
+	path := SettingsPath()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return path, nil
+		}
+		return "", err
+	}
+
+	settings := make(map[string]any)
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return "", err
+	}
+
+	if _, ok := settings["statusLine"]; !ok {
+		return path, nil
+	}
+
+	delete(settings, "statusLine")
+
+	if err := writeSettings(path, settings); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+// readSettings reads and parses the settings file. Returns an empty map if
+// the file does not exist.
+func readSettings(path string) (map[string]any, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return make(map[string]any), nil
+		}
+		return nil, err
+	}
+
+	settings := make(map[string]any)
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return nil, err
+	}
+	return settings, nil
+}
+
+// writeSettings marshals the settings map to JSON and writes it to the given path.
+func writeSettings(path string, settings map[string]any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return os.WriteFile(path, data, 0o600)
+}

--- a/internal/claude/claude_test.go
+++ b/internal/claude/claude_test.go
@@ -1,0 +1,187 @@
+package claude
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDir(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		t.Setenv("CLAUDE_CONFIG_DIR", "")
+		home, err := os.UserHomeDir()
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(home, ".claude"), Dir())
+	})
+
+	t.Run("env override", func(t *testing.T) {
+		t.Setenv("CLAUDE_CONFIG_DIR", "/tmp/custom-claude")
+		assert.Equal(t, "/tmp/custom-claude", Dir())
+	})
+}
+
+func TestSettingsPath(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", "/tmp/test-claude")
+	assert.Equal(t, "/tmp/test-claude/settings.json", SettingsPath())
+}
+
+func TestInstall(t *testing.T) {
+	t.Run("fresh install", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("CLAUDE_CONFIG_DIR", tmpDir)
+
+		path, err := Install()
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(tmpDir, "settings.json"), path)
+
+		data, err := os.ReadFile(path)
+		require.NoError(t, err)
+
+		var settings map[string]any
+		require.NoError(t, json.Unmarshal(data, &settings))
+
+		sl, ok := settings["statusLine"].(map[string]any)
+		require.True(t, ok, "statusLine should be a map")
+		assert.Equal(t, "command", sl["type"])
+		assert.Equal(t, "ccstatus", sl["command"])
+		assert.InDelta(t, 0, sl["padding"], 0.01)
+	})
+
+	t.Run("preserves existing fields", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("CLAUDE_CONFIG_DIR", tmpDir)
+
+		existing := `{
+  "theme": "dark",
+  "autoUpdaterStatus": "disabled"
+}
+`
+		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "settings.json"), []byte(existing), 0o600))
+
+		_, err := Install()
+		require.NoError(t, err)
+
+		data, err := os.ReadFile(filepath.Join(tmpDir, "settings.json"))
+		require.NoError(t, err)
+
+		var settings map[string]any
+		require.NoError(t, json.Unmarshal(data, &settings))
+
+		assert.Equal(t, "dark", settings["theme"])
+		assert.Equal(t, "disabled", settings["autoUpdaterStatus"])
+
+		sl, ok := settings["statusLine"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "ccstatus", sl["command"])
+	})
+
+	t.Run("idempotent", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("CLAUDE_CONFIG_DIR", tmpDir)
+
+		_, err := Install()
+		require.NoError(t, err)
+
+		_, err = Install()
+		require.NoError(t, err)
+
+		data, err := os.ReadFile(filepath.Join(tmpDir, "settings.json"))
+		require.NoError(t, err)
+
+		var settings map[string]any
+		require.NoError(t, json.Unmarshal(data, &settings))
+
+		sl, ok := settings["statusLine"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "ccstatus", sl["command"])
+	})
+}
+
+func TestInstallInvalidJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", tmpDir)
+
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "settings.json"), []byte("{invalid}"), 0o600))
+
+	_, err := Install()
+	assert.Error(t, err)
+}
+
+func TestUninstall(t *testing.T) {
+	t.Run("removes statusLine", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("CLAUDE_CONFIG_DIR", tmpDir)
+
+		existing := `{
+  "theme": "dark",
+  "statusLine": {
+    "type": "command",
+    "command": "ccstatus",
+    "padding": 0
+  }
+}
+`
+		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "settings.json"), []byte(existing), 0o600))
+
+		path, err := Uninstall()
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(tmpDir, "settings.json"), path)
+
+		data, err := os.ReadFile(path)
+		require.NoError(t, err)
+
+		var settings map[string]any
+		require.NoError(t, json.Unmarshal(data, &settings))
+
+		assert.Equal(t, "dark", settings["theme"])
+		_, ok := settings["statusLine"]
+		assert.False(t, ok, "statusLine should be removed")
+	})
+
+	t.Run("no-op when file does not exist", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("CLAUDE_CONFIG_DIR", tmpDir)
+
+		_, err := Uninstall()
+		require.NoError(t, err)
+
+		_, err = os.Stat(filepath.Join(tmpDir, "settings.json"))
+		assert.True(t, os.IsNotExist(err), "file should not be created")
+	})
+
+	t.Run("no-op when statusLine not present", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("CLAUDE_CONFIG_DIR", tmpDir)
+
+		existing := `{
+  "theme": "dark"
+}
+`
+		settingsPath := filepath.Join(tmpDir, "settings.json")
+		require.NoError(t, os.WriteFile(settingsPath, []byte(existing), 0o600))
+
+		_, err := Uninstall()
+		require.NoError(t, err)
+
+		data, err := os.ReadFile(settingsPath)
+		require.NoError(t, err)
+
+		var settings map[string]any
+		require.NoError(t, json.Unmarshal(data, &settings))
+		assert.Equal(t, "dark", settings["theme"])
+	})
+}
+
+func TestUninstallInvalidJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", tmpDir)
+
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "settings.json"), []byte("{invalid}"), 0o600))
+
+	_, err := Uninstall()
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Summary

- Add `internal/claude` package to read/write Claude Code's `settings.json`
- `ccstatus install` registers the statusLine config, preserving existing fields
- `ccstatus uninstall` removes the statusLine config, no-op when absent
- Both commands are idempotent and handle missing files gracefully

## Test plan

- [x] `go test ./internal/claude/...` -- all 8 test cases pass
- [x] `go test ./...` -- full suite passes
- [x] `golangci-lint run` -- 0 issues
- [x] `go build -o ccstatus ./cmd/ccstatus` -- builds successfully