### PR TITLE
feat: add per-render git cache and worktree JSON field support

### DIFF
--- a/cmd/ccstatus/main.go
+++ b/cmd/ccstatus/main.go
@@ -109,6 +109,7 @@ func runStatusLine(_ *cobra.Command, _ []string) error {
 	ctx := widget.RenderContext{
 		Data:          statusData,
 		TerminalWidth: terminal.Width(),
+		Git:           widget.NewGitCache(),
 	}
 
 	// Buffer all lines and write atomically to avoid partial reads

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -21,6 +21,7 @@ type Session struct {
 	Exceeds200K    *bool          `json:"exceeds_200k_tokens,omitempty"`
 	Vim            *VimInfo       `json:"vim,omitempty"`
 	Agent          *AgentInfo     `json:"agent,omitempty"`
+	Worktree       *WorktreeInfo  `json:"worktree,omitempty"`
 }
 
 // Parse parses JSON data into Session.
@@ -135,4 +136,14 @@ type VimInfo struct {
 // AgentInfo is only present when running with --agent flag or agent settings.
 type AgentInfo struct {
 	Name string `json:"name,omitempty"`
+}
+
+// WorktreeInfo is only present during --worktree sessions.
+// The Branch and OriginalBranch fields may be absent for hook-based worktrees.
+type WorktreeInfo struct {
+	Name           string `json:"name,omitempty"`
+	Path           string `json:"path,omitempty"`
+	Branch         string `json:"branch,omitempty"`
+	OriginalCwd    string `json:"original_cwd,omitempty"`
+	OriginalBranch string `json:"original_branch,omitempty"`
 }

--- a/internal/widget/git_branch.go
+++ b/internal/widget/git_branch.go
@@ -2,15 +2,14 @@ package widget
 
 import (
 	"github.com/moond4rk/ccstatus/internal/config"
-	"github.com/moond4rk/ccstatus/internal/git"
 )
 
 // GitBranchWidget displays the current git branch name.
 type GitBranchWidget struct{}
 
 // Render returns the current git branch, optionally prefixed with a character.
-func (w *GitBranchWidget) Render(item *config.WidgetItem, _ RenderContext, _ *config.Settings) string {
-	branch := git.Branch()
+func (w *GitBranchWidget) Render(item *config.WidgetItem, ctx RenderContext, _ *config.Settings) string {
+	branch := ctx.Git.Branch()
 	if branch == "" {
 		return ""
 	}

--- a/internal/widget/git_changes.go
+++ b/internal/widget/git_changes.go
@@ -4,15 +4,14 @@ import (
 	"strconv"
 
 	"github.com/moond4rk/ccstatus/internal/config"
-	"github.com/moond4rk/ccstatus/internal/git"
 )
 
 // GitChangesWidget displays the number of uncommitted changes.
 type GitChangesWidget struct{}
 
 // Render returns the uncommitted change count, or empty if there are none.
-func (w *GitChangesWidget) Render(_ *config.WidgetItem, _ RenderContext, _ *config.Settings) string {
-	n := git.Changes()
+func (w *GitChangesWidget) Render(_ *config.WidgetItem, ctx RenderContext, _ *config.Settings) string {
+	n := ctx.Git.Changes()
 	if n == 0 {
 		return ""
 	}

--- a/internal/widget/git_worktree.go
+++ b/internal/widget/git_worktree.go
@@ -2,15 +2,18 @@ package widget
 
 import (
 	"github.com/moond4rk/ccstatus/internal/config"
-	"github.com/moond4rk/ccstatus/internal/git"
 )
 
 // GitWorktreeWidget displays the current git worktree name.
 type GitWorktreeWidget struct{}
 
 // Render returns the worktree name if in a linked worktree, empty otherwise.
-func (w *GitWorktreeWidget) Render(_ *config.WidgetItem, _ RenderContext, _ *config.Settings) string {
-	return git.Worktree()
+// Prioritizes the JSON worktree field from Claude Code, falls back to git command.
+func (w *GitWorktreeWidget) Render(_ *config.WidgetItem, ctx RenderContext, _ *config.Settings) string {
+	if ctx.Data != nil && ctx.Data.Worktree != nil && ctx.Data.Worktree.Name != "" {
+		return ctx.Data.Worktree.Name
+	}
+	return ctx.Git.Worktree()
 }
 
 // DefaultColor returns the default foreground color.

--- a/internal/widget/lines_changed.go
+++ b/internal/widget/lines_changed.go
@@ -4,15 +4,14 @@ import (
 	"fmt"
 
 	"github.com/moond4rk/ccstatus/internal/config"
-	"github.com/moond4rk/ccstatus/internal/git"
 )
 
 // LinesChangedWidget displays git diff line additions and deletions.
 type LinesChangedWidget struct{}
 
 // Render returns a "+N/-M" format from git diff --shortstat, or empty if clean.
-func (w *LinesChangedWidget) Render(_ *config.WidgetItem, _ RenderContext, _ *config.Settings) string {
-	stat := git.Diff()
+func (w *LinesChangedWidget) Render(_ *config.WidgetItem, ctx RenderContext, _ *config.Settings) string {
+	stat := ctx.Git.Diff()
 	if stat.Added == 0 && stat.Removed == 0 {
 		return ""
 	}
@@ -37,8 +36,8 @@ func (w *LinesChangedWidget) SupportsRawValue() bool { return false }
 type LinesAddedWidget struct{}
 
 // Render returns "+N" from git diff, or empty if zero.
-func (w *LinesAddedWidget) Render(_ *config.WidgetItem, _ RenderContext, _ *config.Settings) string {
-	stat := git.Diff()
+func (w *LinesAddedWidget) Render(_ *config.WidgetItem, ctx RenderContext, _ *config.Settings) string {
+	stat := ctx.Git.Diff()
 	if stat.Added == 0 {
 		return ""
 	}
@@ -61,8 +60,8 @@ func (w *LinesAddedWidget) SupportsRawValue() bool { return false }
 type LinesRemovedWidget struct{}
 
 // Render returns "-N" from git diff, or empty if zero.
-func (w *LinesRemovedWidget) Render(_ *config.WidgetItem, _ RenderContext, _ *config.Settings) string {
-	stat := git.Diff()
+func (w *LinesRemovedWidget) Render(_ *config.WidgetItem, ctx RenderContext, _ *config.Settings) string {
+	stat := ctx.Git.Diff()
 	if stat.Removed == 0 {
 		return ""
 	}

--- a/internal/widget/widget.go
+++ b/internal/widget/widget.go
@@ -3,6 +3,7 @@ package widget
 
 import (
 	"github.com/moond4rk/ccstatus/internal/config"
+	"github.com/moond4rk/ccstatus/internal/git"
 	"github.com/moond4rk/ccstatus/internal/status"
 )
 
@@ -11,6 +12,67 @@ import (
 type RenderContext struct {
 	Data          *status.Session
 	TerminalWidth int
+	Git           *GitCache
+}
+
+// GitCache caches git command results for a single render cycle.
+// Each accessor lazily invokes the underlying git command at most once.
+type GitCache struct {
+	branch   *string
+	changes  *int
+	worktree *string
+	diff     *git.DiffStat
+}
+
+// NewGitCache creates a new empty cache for one render cycle.
+func NewGitCache() *GitCache { return &GitCache{} }
+
+// Branch returns the current git branch, caching the result.
+func (c *GitCache) Branch() string {
+	if c == nil {
+		return git.Branch()
+	}
+	if c.branch == nil {
+		b := git.Branch()
+		c.branch = &b
+	}
+	return *c.branch
+}
+
+// Changes returns the uncommitted change count, caching the result.
+func (c *GitCache) Changes() int {
+	if c == nil {
+		return git.Changes()
+	}
+	if c.changes == nil {
+		n := git.Changes()
+		c.changes = &n
+	}
+	return *c.changes
+}
+
+// Worktree returns the worktree name, caching the result.
+func (c *GitCache) Worktree() string {
+	if c == nil {
+		return git.Worktree()
+	}
+	if c.worktree == nil {
+		w := git.Worktree()
+		c.worktree = &w
+	}
+	return *c.worktree
+}
+
+// Diff returns the line-level diff stats, caching the result.
+func (c *GitCache) Diff() git.DiffStat {
+	if c == nil {
+		return git.Diff()
+	}
+	if c.diff == nil {
+		d := git.Diff()
+		c.diff = &d
+	}
+	return *c.diff
 }
 
 // Widget defines the contract for all status line widgets.


### PR DESCRIPTION
## Summary

- Add `GitCache` to `RenderContext` that lazily caches git command results within a single render cycle, eliminating redundant git process forks (e.g. `git.Diff()` was called 3x per render by lines-changed/added/removed widgets)
- Add `WorktreeInfo` struct to `Session` for the new `worktree` JSON field from the Claude Code status line API (ref: [status line docs](https://code.claude.com/docs/en/statusline))
- Update `git-worktree` widget to prioritize JSON `worktree.name` with fallback to git command

Closes #18, closes #19

## Test plan

- [x] `go test ./...` passes
- [x] `golangci-lint run` reports 0 issues
- [x] Manual test: `echo '{"model":{"display_name":"Sonnet"},"worktree":{"name":"my-feature"}}' | ccstatus` shows worktree name from JSON
- [x] Manual test: `echo '{"model":{"display_name":"Sonnet"}}' | ccstatus` falls back to git command for worktree detection