### PR TITLE
feat: add terminalWidth setting and ancestor-TTY width detection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,8 @@ Data source: (J) = from Claude Code JSON input, (G) = from git commands, (T) = f
 
 Settings stored at `~/.config/ccstatus/settings.json`. Manual editing only.
 
+`terminalWidth` (int, optional): force the status line width when auto-detection is wrong. Claude Code runs the status line command with stdio piped (not a TTY), so `terminal.Width()` often falls back to 80; setting `terminalWidth` overrides that.
+
 ### Claude Code Integration
 
 Reads/writes `~/.claude/settings.json` (or `$CLAUDE_CONFIG_DIR/settings.json`):

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ The default configuration uses a 2-line layout:
 | `colorLevel` | int | `2` | Color level: `0` (none), `1` (basic), `2` (256-color terminal) |
 | `flexMode` | string | `"full-until-compact"` | How flex separator calculates available width |
 | `compactThreshold` | int | `60` | Context % threshold for switching to compact mode |
+| `terminalWidth` | int | (auto) | Force the status line width in columns. Claude Code runs the status line command with stdio piped, so width auto-detection often falls back to 80 regardless of terminal size — set this (e.g. `180`) to make ccstatus use your real width. Leave unset/`0` to auto-detect. |
 | `defaultSeparator` | string | `"\|"` | Separator character between widgets |
 | `defaultPadding` | string | `" "` | Padding around separators |
 | `inheritSeparatorColors` | bool | `false` | Separators inherit color from adjacent widget |

--- a/cmd/ccstatus/cmd_dump.go
+++ b/cmd/ccstatus/cmd_dump.go
@@ -58,7 +58,7 @@ func runDump(cmd *cobra.Command, _ []string) error {
 
 	ctx := widget.RenderContext{
 		Data:          statusData,
-		TerminalWidth: terminal.Width(),
+		TerminalWidth: terminal.Width(settings.TerminalWidth),
 	}
 
 	for _, line := range settings.Lines {

--- a/cmd/ccstatus/main.go
+++ b/cmd/ccstatus/main.go
@@ -108,7 +108,7 @@ func runStatusLine(_ *cobra.Command, _ []string) error {
 
 	ctx := widget.RenderContext{
 		Data:          statusData,
-		TerminalWidth: terminal.Width(),
+		TerminalWidth: terminal.Width(settings.TerminalWidth),
 		Git:           widget.NewGitCache(),
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,7 @@ type Settings struct {
 	FlexMode                string         `json:"flexMode"`
 	CompactThreshold        int            `json:"compactThreshold"`
 	ColorLevel              int            `json:"colorLevel"`
+	TerminalWidth           int            `json:"terminalWidth,omitempty"`
 	DefaultSeparator        string         `json:"defaultSeparator,omitempty"`
 	DefaultPadding          string         `json:"defaultPadding,omitempty"`
 	InheritSeparatorColors  bool           `json:"inheritSeparatorColors"`

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -2,32 +2,54 @@
 package terminal
 
 import (
+	"context"
 	"os"
+	"os/exec"
 	"strconv"
+	"strings"
+	"time"
 
 	"golang.org/x/term"
 )
 
-// defaultWidth is the fallback terminal width when detection fails.
-const defaultWidth = 80
+const (
+	// defaultWidth is the fallback terminal width when detection fails.
+	defaultWidth = 80
+	// maxParentWalk bounds how far up the process tree Width climbs looking
+	// for an ancestor that owns a controlling terminal.
+	maxParentWalk = 8
+	// psTimeout bounds the `ps` call used to inspect an ancestor process.
+	psTimeout = time.Second
+)
 
 // Width returns the terminal width in columns.
-// Detection order: stdout fd, stderr fd, /dev/tty, COLUMNS env, default 80.
-// When running as a piped subprocess (e.g. Claude Code status line command),
-// stdout/stderr are pipes, so /dev/tty is typically the first successful source.
-func Width() int {
-	// Try stdout and stderr fds (works when at least one is a real terminal).
+//
+// If override > 0 it wins (the `terminalWidth` setting; use it when running
+// under a host like Claude Code that pipes stdio and may run the status line
+// command detached from the terminal). Otherwise the detection order is:
+// stdout fd, stderr fd, /dev/tty, the controlling terminal of an ancestor
+// process, the COLUMNS env var, then the default 80.
+func Width(override int) int {
+	if override > 0 {
+		return override
+	}
+	// 1. A standard fd that happens to be a real terminal.
 	for _, f := range []*os.File{os.Stdout, os.Stderr} {
 		if w, _, err := term.GetSize(int(f.Fd())); err == nil && w > 0 { //nolint:gosec // fd values are small, no overflow risk
 			return w
 		}
 	}
-	// Try the controlling terminal directly. This works even when all
-	// standard fds are pipes, as long as a controlling terminal exists.
-	if w := widthFromTTY(); w > 0 {
+	// 2. Our own controlling terminal (works unless we were detached from it).
+	if w := widthFromTTYPath("/dev/tty"); w > 0 {
 		return w
 	}
-	// Fall back to the COLUMNS environment variable.
+	// 3. The controlling terminal of an ancestor process. This recovers the
+	//    real width when the host ran the status line command detached from
+	//    the terminal (so /dev/tty fails) but an ancestor still owns the tty.
+	if w := widthFromAncestorTTY(); w > 0 {
+		return w
+	}
+	// 4. The COLUMNS env var (captured at spawn time, so it can be stale).
 	if cols := os.Getenv("COLUMNS"); cols != "" {
 		if n, err := strconv.Atoi(cols); err == nil && n > 0 {
 			return n
@@ -36,9 +58,9 @@ func Width() int {
 	return defaultWidth
 }
 
-// widthFromTTY opens /dev/tty and queries its width.
-func widthFromTTY() int {
-	f, err := os.Open("/dev/tty")
+// widthFromTTYPath opens a tty device path and returns its width, or 0.
+func widthFromTTYPath(path string) int {
+	f, err := os.Open(path)
 	if err != nil {
 		return 0
 	}
@@ -48,4 +70,61 @@ func widthFromTTY() int {
 		return 0
 	}
 	return w
+}
+
+// widthFromAncestorTTY walks up the process tree and returns the width of the
+// first ancestor that has a controlling terminal, or 0 if none is found.
+func widthFromAncestorTTY() int {
+	pid := os.Getppid()
+	for range maxParentWalk {
+		if pid <= 1 {
+			break
+		}
+		ppid, tty := ppidAndTTY(pid)
+		if w := widthFromTTYName(tty); w > 0 {
+			return w
+		}
+		if ppid <= 1 || ppid == pid {
+			break
+		}
+		pid = ppid
+	}
+	return 0
+}
+
+// ppidAndTTY reports a process's parent pid and controlling tty name via `ps`.
+// Returns (0, "") if the lookup fails.
+func ppidAndTTY(pid int) (ppid int, tty string) {
+	ctx, cancel := context.WithTimeout(context.Background(), psTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "ps", "-o", "ppid=,tty=", "-p", strconv.Itoa(pid)) //nolint:gosec // sanitized pid, not user input
+	out, err := cmd.Output()
+	if err != nil {
+		return 0, ""
+	}
+	fields := strings.Fields(string(out))
+	if len(fields) == 0 {
+		return 0, ""
+	}
+	ppid, _ = strconv.Atoi(fields[0])
+	if len(fields) > 1 {
+		tty = fields[1]
+	}
+	return ppid, tty
+}
+
+// widthFromTTYName resolves a `ps`-style tty name (e.g. "ttys003" on macOS,
+// "pts/3" on Linux) to a device path and returns its width, or 0 if the name is
+// not a real terminal.
+func widthFromTTYName(name string) int {
+	name = strings.TrimSpace(name)
+	switch name {
+	case "", "?", "??", "-":
+		return 0
+	}
+	path := name
+	if !strings.HasPrefix(path, "/") {
+		path = "/dev/" + path
+	}
+	return widthFromTTYPath(path)
 }

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -1,0 +1,38 @@
+package terminal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWidth(t *testing.T) {
+	t.Run("override wins", func(t *testing.T) {
+		assert.Equal(t, 150, Width(150))
+		assert.Equal(t, 200, Width(200))
+	})
+
+	t.Run("auto-detect returns a positive width", func(t *testing.T) {
+		// With no override and (under CI) no usable TTY, Width still returns
+		// a sane positive value (the default fallback at minimum).
+		assert.Positive(t, Width(0))
+	})
+
+	t.Run("non-positive override is ignored", func(t *testing.T) {
+		assert.Positive(t, Width(0))
+		assert.Positive(t, Width(-5))
+	})
+}
+
+func TestWidthFromTTYName(t *testing.T) {
+	for _, name := range []string{"", " ", "?", "??", "-", "nonexistent-tty-xyz"} {
+		assert.Zero(t, widthFromTTYName(name), "name %q should not resolve to a width", name)
+	}
+}
+
+func TestPpidAndTTY(t *testing.T) {
+	// Looking up an obviously invalid pid must not panic and must report no tty.
+	ppid, tty := ppidAndTTY(-1)
+	assert.Zero(t, ppid)
+	assert.Empty(t, tty)
+}


### PR DESCRIPTION
## Why

Claude Code does not pass the terminal width to the status line command — the JSON input has no `columns` field (unlike `subagentStatusLine`, which does). It also runs the command with stdio piped, so `term.GetSize` on stdout/stderr fails and `/dev/tty` only works when the command shares the controlling terminal. When it doesn't (e.g. the command is run detached / in a new session, common in some terminal/IDE setups), width falls back to the hardcoded `80` and a rich status line gets truncated with `...` no matter how wide the terminal actually is.

## Changes

- **Ancestor-TTY detection.** `terminal.Width()` now walks up the process tree (via `ps`, bounded to 8 levels, with a 1s timeout) and uses the controlling terminal of the first ancestor that has one. This recovers the real width when the command is detached but a parent (e.g. Claude Code) still owns the tty. It only runs as a fallback — after stdout/stderr/`/dev/tty` — so there's no cost in the normal case.
- **`terminalWidth` setting.** An explicit override in `~/.config/ccstatus/settings.json`; when `> 0` it short-circuits auto-detection. For people who always run full-screen, or whose terminal genuinely can't be probed.
- New `internal/terminal/terminal_test.go` (the package had no tests).

`go build` / `go test` / `gofmt` / `golangci-lint` all pass.