### PR TITLE
refactor: align widgets and rendering with the status line spec

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Claude Code pipes session JSON to stdin. ccstatus parses it (`internal/status`),
 
 Subcommands: `ccstatus init` (write default settings.json), `validate`, `install` / `uninstall` (manage the `statusLine` block in `~/.claude/settings.json`, or `$CLAUDE_CONFIG_DIR/`; `install` takes `--refresh N` and `--hide-vim-indicator`), `dump` (save the raw Claude Code JSON to `/tmp/ccstatus-dump.json`), `widgets` (list all widget types).
 
-~44 widgets implement `Widget` (`Render` / `DefaultColor` / `DisplayName` / `Description` / `SupportsRawValue`), registered in a map keyed by type string in `internal/widget/widget.go`; generic templates (`tokenWidget`, `percentageWidget`, `stringFieldWidget`, `RateLimitWidget`) back most of them. Data sources: Claude Code JSON, `git` commands, the JSONL transcript (`block-timer` fallback only), the system. `ccstatus widgets` lists them all; `README.md` has per-widget detail.
+~46 widgets implement `Widget` (`Render` / `DefaultColor` / `DisplayName` / `Description` / `SupportsRawValue` / `DefaultPrefix` / `DefaultSuffix` — embed `noAffix` for empty affixes), registered in a map keyed by type string in `internal/widget/widget.go`; generic templates (`tokenWidget`, `percentageWidget`, `stringFieldWidget`, `RateLimitWidget`) back most of them. Data sources: Claude Code JSON, `git` commands (run in the session dir via the injectable `git.Repo`/`GitProvider`), the JSONL transcript (`block-timer` fallback only), the system. `ccstatus widgets` lists them all; `README.md` has per-widget detail.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 # ccstatus
 
-[![Go CI](https://github.com/moond4rk/ccstatus/actions/workflows/ci.yml/badge.svg)](https://github.com/moond4rk/ccstatus/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/moond4rk/ccstatus/branch/main/graph/badge.svg)](https://codecov.io/gh/moond4rk/ccstatus)
-[![Go Reference](https://pkg.go.dev/badge/github.com/moond4rk/ccstatus.svg)](https://pkg.go.dev/github.com/moond4rk/ccstatus)
-[![Go Report Card](https://goreportcard.com/badge/github.com/moond4rk/ccstatus)](https://goreportcard.com/report/github.com/moond4rk/ccstatus)
-[![License](https://img.shields.io/github/license/moond4rk/ccstatus)](https://github.com/moond4rk/ccstatus/blob/main/LICENSE)
+[![Go CI](https://github.com/moond4rk/ccstatus/actions/workflows/ci.yml/badge.svg)](https://github.com/moond4rk/ccstatus/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/moond4rk/ccstatus/branch/main/graph/badge.svg)](https://codecov.io/gh/moond4rk/ccstatus) [![Go Reference](https://pkg.go.dev/badge/github.com/moond4rk/ccstatus.svg)](https://pkg.go.dev/github.com/moond4rk/ccstatus) [![Go Report Card](https://goreportcard.com/badge/github.com/moond4rk/ccstatus)](https://goreportcard.com/report/github.com/moond4rk/ccstatus) [![License](https://img.shields.io/github/license/moond4rk/ccstatus)](https://github.com/moond4rk/ccstatus/blob/main/LICENSE)
 
 A customizable status line formatter for [Claude Code](https://code.claude.com/) CLI. Reads JSON session data from stdin, renders an ANSI-colored status line, and outputs to stdout.
 
@@ -15,7 +11,7 @@ A customizable status line formatter for [Claude Code](https://code.claude.com/)
 ## Features
 
 - Single static binary with no runtime dependencies
-- 44 configurable widgets (model, tokens, context, git, cost, rate limits, and more)
+- 46 configurable widgets (model, tokens, context, git, cost, rate limits, and more)
 - Multi-line status line with flex separator layout
 - ANSI 16-color support via [fatih/color](https://github.com/fatih/color)
 - Configurable via `~/.config/ccstatus/settings.json`
@@ -57,7 +53,7 @@ ccstatus [command]
 ### Commands
 
 | Command | Description |
-|---------|-------------|
+| --- | --- |
 | `init` | Generate default `settings.json` at the ccstatus config directory |
 | `install` | Register ccstatus as the status line command in Claude Code's `settings.json` |
 | `uninstall` | Remove ccstatus status line configuration from Claude Code's `settings.json` |
@@ -68,10 +64,10 @@ ccstatus [command]
 
 ### Global Flags
 
-| Flag | Description |
-|------|-------------|
-| `-h, --help` | Show help for any command |
-| `-v, --version` | Print version |
+| Flag            | Description               |
+| --------------- | ------------------------- |
+| `-h, --help`    | Show help for any command |
+| `-v, --version` | Print version             |
 
 ### Command Details
 
@@ -120,7 +116,7 @@ Removes the ccstatus status line configuration from Claude Code's settings.
 ccstatus validate
 ```
 
-Checks `settings.json` for errors such as unknown widget types, missing IDs, or invalid color names.
+Checks `settings.json` for unknown widget types, missing or duplicate widget IDs, and invalid color names. Exits non-zero when any problem is found, so it works as a CI gate.
 
 #### `ccstatus dump`
 
@@ -184,9 +180,9 @@ To customize, edit the `lines` array in `settings.json` — e.g. swap `rate-limi
   "globalBold": false,
   "lines": [
     [
-      {"id": "1", "type": "model", "color": "cyan"},
-      {"id": "2", "type": "separator"},
-      {"id": "3", "type": "context-percentage", "color": "brightBlack"}
+      { "id": "1", "type": "model", "color": "cyan" },
+      { "id": "2", "type": "separator" },
+      { "id": "3", "type": "context-percentage", "color": "brightBlack" }
     ]
   ]
 }
@@ -195,7 +191,7 @@ To customize, edit the `lines` array in `settings.json` — e.g. swap `rate-limi
 ### Global Settings
 
 | Field | Type | Default | Description |
-|-------|------|---------|-------------|
+| --- | --- | --- | --- |
 | `version` | int | `4` | Config schema version |
 | `colorLevel` | int | `2` | `0` disables color; any value `>= 1` enables ANSI 16-color output |
 | `flexMode` | string | `"full-until-compact"` | How flex separator calculates available width |
@@ -209,7 +205,7 @@ To customize, edit the `lines` array in `settings.json` — e.g. swap `rate-limi
 ### Widget Item Options
 
 | Field | Type | Description |
-|-------|------|-------------|
+| --- | --- | --- |
 | `id` | string | Unique identifier |
 | `type` | string | Widget type (see list below) |
 | `color` | string | Foreground color name |
@@ -225,7 +221,7 @@ To customize, edit the `lines` array in `settings.json` — e.g. swap `rate-limi
 ### Flex Modes
 
 | Mode | Description |
-|------|-------------|
+| --- | --- |
 | `full` | Terminal width - 10 characters |
 | `full-minus-40` | Terminal width - 40 characters |
 | `full-until-compact` | Terminal width - 10, switching to - 40 once context % >= `compactThreshold` (default) |
@@ -239,7 +235,7 @@ To customize, edit the `lines` array in `settings.json` — e.g. swap `rate-limi
 ## Available Widgets
 
 | Widget | Source | Description | Default Color |
-|--------|--------|-------------|---------------|
+| --- | --- | --- | --- |
 | `model` | JSON | Current Claude model name | cyan |
 | `version` | JSON | Claude Code version | white |
 | `session-id` | JSON | Session ID (8-char short) | white |
@@ -259,7 +255,7 @@ To customize, edit the `lines` array in `settings.json` — e.g. swap `rate-limi
 | `cache-creation` | JSON | Cache creation tokens | white |
 | `context-length` | JSON | Context usage in tokens | white |
 | `context-percentage` | JSON | Context usage % | white |
-| `context-percentage-usable` | JSON | Usable context % (80% of max) | white |
+| `context-percentage-usable` | JSON | Usable context % (heuristic: 80% of max, leaving auto-compact headroom) | white |
 | `remaining-percentage` | JSON | Remaining context % | white |
 | `cache-hit-rate` | JSON | Cache read ratio % | cyan |
 | `api-duration` | JSON | API response time | white |
@@ -271,6 +267,8 @@ To customize, edit the `lines` array in `settings.json` — e.g. swap `rate-limi
 | `project-dir` | JSON | Project root directory | blue |
 | `transcript-path` | JSON | Transcript file path | white |
 | `added-dirs` | JSON | Directories added via `/add-dir` (`metadata.display`: `list` for names) | blue |
+| `repo` | JSON | Repository `owner/name` from the origin remote (raw: name only) | blue |
+| `pr` | JSON | Open PR number + review state, e.g. `#1234 approved` (raw: number) | cyan |
 | `lines-changed` | Git | Lines changed (+N/-M) | green |
 | `lines-added` | Git | Lines added | green |
 | `lines-removed` | Git | Lines removed | red |
@@ -294,6 +292,8 @@ Claude Code  --[JSON]--> ccstatus --[ANSI text]--> status line
 ```
 
 For the full JSON schema, see the [official documentation](https://code.claude.com/docs/en/statusline).
+
+> **Not yet supported:** the separate [`subagentStatusLine`](https://code.claude.com/docs/en/statusline#subagent-status-lines) setting (a per-subagent row in the agent panel) has a different input/output contract and is tracked for a future release.
 
 ## Debugging
 

--- a/cmd/ccstatus/cmd_dump.go
+++ b/cmd/ccstatus/cmd_dump.go
@@ -59,6 +59,8 @@ func runDump(cmd *cobra.Command, _ []string) error {
 	ctx := widget.RenderContext{
 		Data:          statusData,
 		TerminalWidth: terminal.Width(settings.TerminalWidth),
+		Git:           widget.NewGitCache(statusData.WorkingDir()),
+		RawInput:      data,
 	}
 
 	for _, line := range settings.Lines {

--- a/cmd/ccstatus/cmd_install.go
+++ b/cmd/ccstatus/cmd_install.go
@@ -17,6 +17,7 @@ func newInstallCmd() *cobra.Command {
 		RunE:  runInstall,
 	}
 	cmd.Flags().Int("refresh", 0, "Re-run the status line every N seconds (writes refreshInterval; 0 = unset)")
+	cmd.Flags().Int("padding", 0, "Horizontal padding added to the status line (writes padding)")
 	cmd.Flags().Bool("hide-vim-indicator", false, "Suppress Claude Code's built-in vim mode indicator (writes hideVimModeIndicator)")
 	return cmd
 }
@@ -31,9 +32,23 @@ func newUninstallCmd() *cobra.Command {
 }
 
 func runInstall(cmd *cobra.Command, _ []string) error {
-	refresh, _ := cmd.Flags().GetInt("refresh")
-	hideVim, _ := cmd.Flags().GetBool("hide-vim-indicator")
-	path, err := claude.Install(refresh, hideVim)
+	// Only flags the user explicitly set become overrides; unset flags preserve
+	// the current statusLine values on re-install.
+	var opts claude.InstallOptions
+	if cmd.Flags().Changed("refresh") {
+		v, _ := cmd.Flags().GetInt("refresh")
+		opts.RefreshInterval = &v
+	}
+	if cmd.Flags().Changed("padding") {
+		v, _ := cmd.Flags().GetInt("padding")
+		opts.Padding = &v
+	}
+	if cmd.Flags().Changed("hide-vim-indicator") {
+		v, _ := cmd.Flags().GetBool("hide-vim-indicator")
+		opts.HideVimMode = &v
+	}
+
+	path, err := claude.Install(opts)
 	if err != nil {
 		return err
 	}

--- a/cmd/ccstatus/cmd_validate.go
+++ b/cmd/ccstatus/cmd_validate.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
+	"github.com/moond4rk/ccstatus/internal/color"
 	"github.com/moond4rk/ccstatus/internal/config"
 	"github.com/moond4rk/ccstatus/internal/widget"
 )
@@ -19,27 +19,67 @@ func newValidateCmd() *cobra.Command {
 	}
 }
 
-func runValidate(_ *cobra.Command, _ []string) error {
+// runValidate checks the loaded settings for unknown widget types, missing or
+// duplicate widget IDs, and invalid color names. It reports every problem and
+// exits non-zero when any are found, so it is usable as a CI gate.
+func runValidate(cmd *cobra.Command, _ []string) error {
 	settings, err := config.Load()
 	if err != nil {
 		return fmt.Errorf("invalid settings: %w", err)
 	}
 
-	// Check for unknown widget types.
-	var warnings []string
-	for _, line := range settings.Lines {
-		for i := range line {
-			if widget.Get(line[i].Type) == nil {
-				warnings = append(warnings, fmt.Sprintf("unknown widget type: %q", line[i].Type))
-			}
+	problems := collectProblems(&settings)
+
+	if len(problems) > 0 {
+		for _, p := range problems {
+			fmt.Fprintln(cmd.ErrOrStderr(), "Error:", p)
+		}
+		return fmt.Errorf("%d problem(s) found in %s", len(problems), config.Path())
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), "Settings are valid")
+	return nil
+}
+
+// collectProblems returns a human-readable list of configuration problems, in
+// document order so the output is stable.
+func collectProblems(settings *config.Settings) []string {
+	var problems []string
+	seen := make(map[string]bool)
+
+	checkColor := func(loc, kind, val string) {
+		if val != "" && !color.IsNamed(val) {
+			problems = append(problems, fmt.Sprintf("%s: invalid %s %q", loc, kind, val))
 		}
 	}
 
-	if len(warnings) > 0 {
-		for _, w := range warnings {
-			fmt.Fprintf(os.Stderr, "Warning: %s\n", w)
+	for li, line := range settings.Lines {
+		for i := range line {
+			item := &line[i]
+			loc := fmt.Sprintf("line %d widget %d", li+1, i+1)
+
+			switch {
+			case item.Type == "":
+				problems = append(problems, loc+": missing widget type")
+			case widget.Get(item.Type) == nil:
+				problems = append(problems, fmt.Sprintf("%s: unknown widget type %q", loc, item.Type))
+			}
+
+			switch {
+			case item.ID == "":
+				problems = append(problems, loc+": missing id")
+			case seen[item.ID]:
+				problems = append(problems, fmt.Sprintf("%s: duplicate id %q", loc, item.ID))
+			default:
+				seen[item.ID] = true
+			}
+
+			checkColor(loc, "color", item.Color)
+			checkColor(loc, "backgroundColor", item.BackgroundColor)
 		}
 	}
-	fmt.Fprintln(os.Stderr, "Settings are valid")
-	return nil
+
+	checkColor("settings", "overrideForegroundColor", settings.OverrideForegroundColor)
+	checkColor("settings", "overrideBackgroundColor", settings.OverrideBackgroundColor)
+
+	return problems
 }

--- a/cmd/ccstatus/cmd_validate_test.go
+++ b/cmd/ccstatus/cmd_validate_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moond4rk/ccstatus/internal/config"
+)
+
+// saveConfigWithLines points XDG_CONFIG_HOME at a temp dir and writes a config
+// whose Lines are replaced with the given widgets.
+func saveConfigWithLines(t *testing.T, lines [][]config.WidgetItem) {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	s := config.DefaultSettings()
+	s.Lines = lines
+	require.NoError(t, config.Save(&s))
+}
+
+func execValidate(t *testing.T) (stdout, stderr string, err error) {
+	t.Helper()
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"validate"})
+	var o, e bytes.Buffer
+	cmd.SetOut(&o)
+	cmd.SetErr(&e)
+	err = cmd.Execute()
+	return o.String(), e.String(), err
+}
+
+func TestValidate(t *testing.T) {
+	t.Run("default config is valid", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir()) // no file -> defaults
+		out, _, err := execValidate(t)
+		require.NoError(t, err)
+		assert.Contains(t, out, "Settings are valid")
+	})
+
+	t.Run("unknown widget type fails", func(t *testing.T) {
+		saveConfigWithLines(t, [][]config.WidgetItem{{{ID: "1", Type: "no-such-widget"}}})
+		_, errOut, err := execValidate(t)
+		require.Error(t, err)
+		assert.Contains(t, errOut, "unknown widget type")
+	})
+
+	t.Run("missing id fails", func(t *testing.T) {
+		saveConfigWithLines(t, [][]config.WidgetItem{{{Type: "model"}}})
+		_, errOut, err := execValidate(t)
+		require.Error(t, err)
+		assert.Contains(t, errOut, "missing id")
+	})
+
+	t.Run("duplicate id fails", func(t *testing.T) {
+		saveConfigWithLines(t, [][]config.WidgetItem{{
+			{ID: "1", Type: "model"},
+			{ID: "1", Type: "version"},
+		}})
+		_, errOut, err := execValidate(t)
+		require.Error(t, err)
+		assert.Contains(t, errOut, "duplicate id")
+	})
+
+	t.Run("invalid color fails", func(t *testing.T) {
+		saveConfigWithLines(t, [][]config.WidgetItem{{{ID: "1", Type: "model", Color: "chartreuse"}}})
+		_, errOut, err := execValidate(t)
+		require.Error(t, err)
+		assert.Contains(t, errOut, "invalid color")
+	})
+
+	t.Run("does not print valid when problems exist", func(t *testing.T) {
+		saveConfigWithLines(t, [][]config.WidgetItem{{{ID: "1", Type: "no-such-widget"}}})
+		out, _, err := execValidate(t)
+		require.Error(t, err)
+		assert.NotContains(t, out, "Settings are valid")
+	})
+}

--- a/cmd/ccstatus/main.go
+++ b/cmd/ccstatus/main.go
@@ -90,8 +90,8 @@ func newRootCmd() *cobra.Command {
 	return cmd
 }
 
-func runStatusLine(_ *cobra.Command, _ []string) error {
-	data, err := io.ReadAll(os.Stdin)
+func runStatusLine(cmd *cobra.Command, _ []string) error {
+	data, err := io.ReadAll(cmd.InOrStdin())
 	if err != nil {
 		return fmt.Errorf("reading stdin: %w", err)
 	}
@@ -109,7 +109,8 @@ func runStatusLine(_ *cobra.Command, _ []string) error {
 	ctx := widget.RenderContext{
 		Data:          statusData,
 		TerminalWidth: terminal.Width(settings.TerminalWidth),
-		Git:           widget.NewGitCache(),
+		Git:           widget.NewGitCache(statusData.WorkingDir()),
+		RawInput:      data,
 	}
 
 	// Buffer all lines and write atomically to avoid partial reads
@@ -124,7 +125,7 @@ func runStatusLine(_ *cobra.Command, _ []string) error {
 		}
 	}
 	if buf.Len() > 0 {
-		fmt.Print(buf.String())
+		fmt.Fprint(cmd.OutOrStdout(), buf.String())
 	}
 	return nil
 }

--- a/cmd/ccstatus/main_test.go
+++ b/cmd/ccstatus/main_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moond4rk/ccstatus/internal/color"
+	"github.com/moond4rk/ccstatus/internal/config"
+)
+
+// runRoot feeds stdin to the root command (the status-line path) and returns the
+// captured stdout normalized back to plain text (ANSI stripped, the VSCode
+// non-breaking spaces restored to ordinary spaces).
+func runRoot(t *testing.T, stdin string) (string, error) {
+	t.Helper()
+	cmd := newRootCmd()
+	cmd.SetIn(strings.NewReader(stdin))
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+	normalized := strings.ReplaceAll(color.StripANSI(out.String()), " ", " ")
+	return normalized, err
+}
+
+// writeDeterministicConfig points XDG_CONFIG_HOME at a temp dir holding a config
+// with only data-driven widgets (no git/clock), so the rendered line is stable.
+func writeDeterministicConfig(t *testing.T) {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	s := config.DefaultSettings()
+	s.ColorLevel = 0
+	s.TerminalWidth = 200
+	s.Lines = [][]config.WidgetItem{{
+		{ID: "1", Type: "model"},
+		{ID: "2", Type: "separator"},
+		{ID: "3", Type: "context-percentage"},
+	}}
+	require.NoError(t, config.Save(&s))
+}
+
+func TestRunStatusLineEndToEnd(t *testing.T) {
+	writeDeterministicConfig(t)
+
+	t.Run("renders the canonical payload", func(t *testing.T) {
+		in := `{"model":{"id":"claude-opus-4-8","display_name":"Opus"},` +
+			`"context_window":{"used_percentage":25,"context_window_size":200000}}`
+		out, err := runRoot(t, in)
+		require.NoError(t, err)
+		assert.Equal(t, "Opus | Ctx: 25%\n", out)
+	})
+
+	t.Run("null payload renders nothing", func(t *testing.T) {
+		out, err := runRoot(t, "null")
+		require.NoError(t, err)
+		assert.Empty(t, out)
+	})
+
+	t.Run("empty stdin errors without panicking", func(t *testing.T) {
+		_, err := runRoot(t, "")
+		assert.Error(t, err)
+	})
+}
+
+func TestRootCommandRegistersSubcommands(t *testing.T) {
+	cmd := newRootCmd()
+	got := map[string]bool{}
+	for _, c := range cmd.Commands() {
+		got[c.Name()] = true
+	}
+	for _, want := range []string{"init", "validate", "install", "uninstall", "dump", "widgets"} {
+		assert.Truef(t, got[want], "subcommand %q should be registered", want)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,14 @@ go 1.26.2
 
 require (
 	github.com/fatih/color v1.19.0
+	github.com/mattn/go-runewidth v0.0.24
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/term v0.44.0
 )
 
 require (
+	github.com/clipperhouse/uax29/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/clipperhouse/uax29/v2 v2.2.0 h1:ChwIKnQN3kcZteTXMgb1wztSgaU+ZemkgWdohwgs8tY=
+github.com/clipperhouse/uax29/v2 v2.2.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -9,6 +11,8 @@ github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHP
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw4=
 github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
+github.com/mattn/go-runewidth v0.0.24 h1:cpokDiIn0MGnhdHwuWnJBITySJ20QyNGnY2kR/ay2DU=
+github.com/mattn/go-runewidth v0.0.24/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/internal/claude/claude.go
+++ b/internal/claude/claude.go
@@ -37,27 +37,46 @@ func SettingsPath() string {
 	return filepath.Join(Dir(), settingsFileName)
 }
 
-// Install registers ccstatus in Claude Code's settings.json. It preserves all
-// existing fields and creates the file if it does not exist. A positive
-// refreshInterval (seconds) and hideVimMode=true are written into the statusLine
-// block; otherwise those keys are omitted. Returns the path to the written file.
-func Install(refreshInterval int, hideVimMode bool) (string, error) {
+// InstallOptions configures the statusLine block written by Install. A nil field
+// leaves that setting at its existing value (or its default on a fresh install)
+// rather than overwriting it, so re-installing never silently drops a setting.
+type InstallOptions struct {
+	RefreshInterval *int  // > 0 sets refreshInterval; <= 0 clears it
+	Padding         *int  // sets padding
+	HideVimMode     *bool // true sets hideVimModeIndicator; false clears it
+}
+
+// Install registers ccstatus as the statusLine command in Claude Code's
+// settings.json. It preserves every other top-level field and every statusLine
+// field not overridden by opts, creating the file if it does not exist. Returns
+// the path to the written file.
+func Install(opts InstallOptions) (string, error) {
 	path := SettingsPath()
 	settings, err := readSettings(path)
 	if err != nil {
 		return "", err
 	}
 
-	sl := StatusLine{
-		Type:    "command",
-		Command: "ccstatus",
-		Padding: 0,
+	sl := existingStatusLine(settings)
+	sl.Type = "command"
+	sl.Command = "ccstatus"
+	if opts.Padding != nil {
+		sl.Padding = *opts.Padding
 	}
-	if refreshInterval > 0 {
-		sl.RefreshInterval = &refreshInterval
+	if opts.RefreshInterval != nil {
+		if v := *opts.RefreshInterval; v > 0 {
+			sl.RefreshInterval = &v
+		} else {
+			sl.RefreshInterval = nil
+		}
 	}
-	if hideVimMode {
-		sl.HideVimModeIndicator = &hideVimMode
+	if opts.HideVimMode != nil {
+		if *opts.HideVimMode {
+			enabled := true
+			sl.HideVimModeIndicator = &enabled
+		} else {
+			sl.HideVimModeIndicator = nil
+		}
 	}
 	settings["statusLine"] = sl
 
@@ -65,6 +84,24 @@ func Install(refreshInterval int, hideVimMode bool) (string, error) {
 		return "", err
 	}
 	return path, nil
+}
+
+// existingStatusLine extracts the current statusLine block so unspecified fields
+// survive a re-install. Returns the zero StatusLine when absent or unparsable.
+func existingStatusLine(settings map[string]any) StatusLine {
+	raw, ok := settings["statusLine"]
+	if !ok {
+		return StatusLine{}
+	}
+	b, err := json.Marshal(raw)
+	if err != nil {
+		return StatusLine{}
+	}
+	var sl StatusLine
+	if err := json.Unmarshal(b, &sl); err != nil {
+		return StatusLine{}
+	}
+	return sl
 }
 
 // Uninstall removes the ccstatus statusLine from Claude Code's settings.json.

--- a/internal/claude/claude_test.go
+++ b/internal/claude/claude_test.go
@@ -10,6 +10,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func ptr[T any](v T) *T { return &v }
+
+// readStatusLine reads settings.json at path and returns its statusLine block.
+func readStatusLine(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var settings map[string]any
+	require.NoError(t, json.Unmarshal(data, &settings))
+	sl, ok := settings["statusLine"].(map[string]any)
+	require.True(t, ok, "statusLine should be a map")
+	return sl
+}
+
 func TestDir(t *testing.T) {
 	t.Run("default", func(t *testing.T) {
 		t.Setenv("CLAUDE_CONFIG_DIR", "")
@@ -34,7 +48,7 @@ func TestInstall(t *testing.T) {
 		tmpDir := t.TempDir()
 		t.Setenv("CLAUDE_CONFIG_DIR", tmpDir)
 
-		path, err := Install(0, false)
+		path, err := Install(InstallOptions{})
 		require.NoError(t, err)
 		assert.Equal(t, filepath.Join(tmpDir, "settings.json"), path)
 
@@ -59,7 +73,7 @@ func TestInstall(t *testing.T) {
 		tmpDir := t.TempDir()
 		t.Setenv("CLAUDE_CONFIG_DIR", tmpDir)
 
-		_, err := Install(5, true)
+		_, err := Install(InstallOptions{RefreshInterval: ptr(5), HideVimMode: ptr(true)})
 		require.NoError(t, err)
 
 		data, err := os.ReadFile(filepath.Join(tmpDir, "settings.json"))
@@ -74,6 +88,36 @@ func TestInstall(t *testing.T) {
 		assert.Equal(t, true, sl["hideVimModeIndicator"])
 	})
 
+	t.Run("--padding sets padding", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("CLAUDE_CONFIG_DIR", tmpDir)
+
+		_, err := Install(InstallOptions{Padding: ptr(3)})
+		require.NoError(t, err)
+
+		sl := readStatusLine(t, filepath.Join(tmpDir, "settings.json"))
+		assert.InDelta(t, 3, sl["padding"], 0.01)
+	})
+
+	t.Run("re-install preserves hand-set padding and refreshInterval", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("CLAUDE_CONFIG_DIR", tmpDir)
+
+		existing := `{
+  "statusLine": { "type": "command", "command": "ccstatus", "padding": 4, "refreshInterval": 7 }
+}
+`
+		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "settings.json"), []byte(existing), 0o600))
+
+		// Re-install with no overrides must not clobber padding or refreshInterval.
+		_, err := Install(InstallOptions{})
+		require.NoError(t, err)
+
+		sl := readStatusLine(t, filepath.Join(tmpDir, "settings.json"))
+		assert.InDelta(t, 4, sl["padding"], 0.01)
+		assert.InDelta(t, 7, sl["refreshInterval"], 0.01)
+	})
+
 	t.Run("preserves existing fields", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		t.Setenv("CLAUDE_CONFIG_DIR", tmpDir)
@@ -85,7 +129,7 @@ func TestInstall(t *testing.T) {
 `
 		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "settings.json"), []byte(existing), 0o600))
 
-		_, err := Install(0, false)
+		_, err := Install(InstallOptions{})
 		require.NoError(t, err)
 
 		data, err := os.ReadFile(filepath.Join(tmpDir, "settings.json"))
@@ -106,10 +150,10 @@ func TestInstall(t *testing.T) {
 		tmpDir := t.TempDir()
 		t.Setenv("CLAUDE_CONFIG_DIR", tmpDir)
 
-		_, err := Install(0, false)
+		_, err := Install(InstallOptions{})
 		require.NoError(t, err)
 
-		_, err = Install(0, false)
+		_, err = Install(InstallOptions{})
 		require.NoError(t, err)
 
 		data, err := os.ReadFile(filepath.Join(tmpDir, "settings.json"))
@@ -130,7 +174,7 @@ func TestInstallInvalidJSON(t *testing.T) {
 
 	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "settings.json"), []byte("{invalid}"), 0o600))
 
-	_, err := Install(0, false)
+	_, err := Install(InstallOptions{})
 	assert.Error(t, err)
 }
 

--- a/internal/color/color.go
+++ b/internal/color/color.go
@@ -3,10 +3,18 @@ package color
 
 import (
 	"strings"
-	"unicode/utf8"
 
 	fcolor "github.com/fatih/color"
+	"github.com/mattn/go-runewidth"
 )
+
+// cellWidth measures terminal display width with East Asian "ambiguous" runes
+// treated as width 1, so results are stable regardless of the host locale.
+var cellWidth = func() *runewidth.Condition {
+	c := runewidth.NewCondition()
+	c.EastAsianWidth = false
+	return c
+}()
 
 // fgToBGOffset is the ANSI standard offset from foreground to background codes.
 // FG: 30-37, BG: 40-47 (diff=10); FG: 90-97, BG: 100-107 (diff=10).
@@ -31,6 +39,13 @@ var namedColors = map[string]fcolor.Attribute{
 	"brightMagenta": fcolor.FgHiMagenta,
 	"brightCyan":    fcolor.FgHiCyan,
 	"brightWhite":   fcolor.FgHiWhite,
+}
+
+// IsNamed reports whether name is a recognized color name. The empty string is
+// not a named color: callers treat empty as "use the widget default".
+func IsNamed(name string) bool {
+	_, ok := namedColors[name]
+	return ok
 }
 
 // Apply wraps text with ANSI color codes based on the given color level.
@@ -62,33 +77,68 @@ func Apply(text, fg, bg string, bold bool, level int) string {
 	return c.Sprint(text)
 }
 
-// StripANSI removes all ANSI escape sequences from a string.
+// StripANSI removes ANSI escape sequences from a string, including CSI color
+// codes and OSC sequences such as OSC 8 hyperlinks.
 func StripANSI(s string) string {
-	var result strings.Builder
-	result.Grow(len(s))
+	var b strings.Builder
+	b.Grow(len(s))
 	i := 0
 	for i < len(s) {
-		if s[i] == '\x1b' && i+1 < len(s) && s[i+1] == '[' {
-			j := i + 2
-			for j < len(s) && !isTerminator(s[j]) {
-				j++
-			}
-			if j < len(s) {
-				j++
-			}
-			i = j
+		if s[i] == '\x1b' {
+			i = ScanEscape(s, i)
 			continue
 		}
-		result.WriteByte(s[i])
+		b.WriteByte(s[i])
 		i++
 	}
-	return result.String()
+	return b.String()
 }
 
-// VisibleWidth returns the number of visible characters (runes) in a string,
-// ignoring ANSI escape sequences.
+// VisibleWidth returns the terminal display width of s, ignoring ANSI escape
+// sequences and counting wide (CJK, emoji) runes as 2 and zero-width (combining)
+// runes as 0.
 func VisibleWidth(s string) int {
-	return utf8.RuneCountInString(StripANSI(s))
+	return cellWidth.StringWidth(StripANSI(s))
+}
+
+// RuneWidth returns the terminal display width of a single rune (0, 1, or 2).
+func RuneWidth(r rune) int {
+	return cellWidth.RuneWidth(r)
+}
+
+// ScanEscape returns the index just past the ANSI escape sequence beginning at
+// s[i] (which must be ESC, 0x1b): CSI (ESC [ ... final letter) or OSC
+// (ESC ] ... terminated by BEL or ST). An unrecognized or truncated sequence
+// consumes the lone ESC and returns i+1.
+func ScanEscape(s string, i int) int {
+	if i+1 >= len(s) || s[i] != '\x1b' {
+		return i + 1
+	}
+	switch s[i+1] {
+	case '[': // CSI
+		j := i + 2
+		for j < len(s) && !isTerminator(s[j]) {
+			j++
+		}
+		if j < len(s) {
+			j++ // include the final byte
+		}
+		return j
+	case ']': // OSC, terminated by BEL (0x07) or ST (ESC \)
+		j := i + 2
+		for j < len(s) {
+			if s[j] == '\x07' {
+				return j + 1
+			}
+			if s[j] == '\x1b' && j+1 < len(s) && s[j+1] == '\\' {
+				return j + 2
+			}
+			j++
+		}
+		return j
+	default:
+		return i + 1
+	}
 }
 
 func isTerminator(b byte) bool {

--- a/internal/color/color_test.go
+++ b/internal/color/color_test.go
@@ -114,6 +114,16 @@ func TestStripANSI(t *testing.T) {
 			input: "\x1b[0m\x1b[36m\x1b[0m",
 			want:  "",
 		},
+		{
+			name:  "OSC 8 hyperlink (BEL-terminated)",
+			input: "\x1b]8;;https://example.com\x07link\x1b]8;;\x07",
+			want:  "link",
+		},
+		{
+			name:  "OSC 8 hyperlink (ST-terminated)",
+			input: "\x1b]8;;https://example.com\x1b\\link\x1b]8;;\x1b\\",
+			want:  "link",
+		},
 	}
 
 	for _, tt := range tests {
@@ -133,7 +143,10 @@ func TestVisibleWidth(t *testing.T) {
 		{name: "colored text", input: "\x1b[36mhello\x1b[0m", want: 5},
 		{name: "empty", input: "", want: 0},
 		{name: "only ANSI", input: "\x1b[0m", want: 0},
-		{name: "unicode", input: "cafe\u0301", want: 5},
+		{name: "combining mark is zero-width", input: "cafe\u0301", want: 4},
+		{name: "CJK is double-width", input: "\u4f60\u597d\u4e16\u754c", want: 8},
+		{name: "emoji is double-width", input: "\U0001F680", want: 2},
+		{name: "OSC 8 hyperlink counts only visible text", input: "\x1b]8;;https://x.com\x07link\x1b]8;;\x07", want: 4},
 	}
 
 	for _, tt := range tests {

--- a/internal/git/changes.go
+++ b/internal/git/changes.go
@@ -1,24 +1,13 @@
 package git
 
-import (
-	"context"
-	"os/exec"
-	"strings"
-)
+import "strings"
 
 // Changes returns the number of uncommitted changes (staged + unstaged + untracked).
 // Returns 0 if not in a git repository or on error.
-func Changes() int {
-	ctx, cancel := context.WithTimeout(context.Background(), gitTimeout)
-	defer cancel()
-	cmd := exec.CommandContext(ctx, "git", "status", "--porcelain")
-	out, err := cmd.Output()
-	if err != nil {
+func (r Repo) Changes() int {
+	out, ok := r.run("status", "--porcelain")
+	if !ok || out == "" {
 		return 0
 	}
-	trimmed := strings.TrimSpace(string(out))
-	if trimmed == "" {
-		return 0
-	}
-	return len(strings.Split(trimmed, "\n"))
+	return len(strings.Split(out, "\n"))
 }

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -1,8 +1,6 @@
 package git
 
 import (
-	"context"
-	"os/exec"
 	"strconv"
 	"strings"
 )
@@ -16,11 +14,9 @@ type DiffStat struct {
 // Diff returns the number of lines added and removed in the working tree
 // (staged + unstaged) compared to HEAD. Returns zero values if not in a git
 // repository or on error.
-func Diff() DiffStat {
-	// Staged changes (index vs HEAD)
-	staged := diffShortStat("--cached")
-	// Unstaged changes (working tree vs index)
-	unstaged := diffShortStat()
+func (r Repo) Diff() DiffStat {
+	staged := r.diffShortStat("--cached") // index vs HEAD
+	unstaged := r.diffShortStat()         // working tree vs index
 	return DiffStat{
 		Added:   staged.Added + unstaged.Added,
 		Removed: staged.Removed + unstaged.Removed,
@@ -29,17 +25,13 @@ func Diff() DiffStat {
 
 // diffShortStat runs git diff --shortstat with optional extra args and parses the output.
 // Output format: " 3 files changed, 10 insertions(+), 5 deletions(-)"
-func diffShortStat(extraArgs ...string) DiffStat {
-	ctx, cancel := context.WithTimeout(context.Background(), gitTimeout)
-	defer cancel()
-
+func (r Repo) diffShortStat(extraArgs ...string) DiffStat {
 	args := append([]string{"diff", "--shortstat"}, extraArgs...)
-	cmd := exec.CommandContext(ctx, "git", args...)
-	out, err := cmd.Output()
-	if err != nil {
+	out, ok := r.run(args...)
+	if !ok {
 		return DiffStat{}
 	}
-	return parseShortStat(strings.TrimSpace(string(out)))
+	return parseShortStat(out)
 }
 
 // parseShortStat parses git diff --shortstat output.

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -10,14 +10,32 @@ import (
 
 const gitTimeout = 5 * time.Second
 
-// Branch returns the current git branch name, or empty string if not in a git repository.
-func Branch() string {
+// Repo runs git commands against a working directory. The zero value runs git
+// in the process's own current working directory; set Dir to the session
+// directory (e.g. workspace.current_dir) so widgets read the right repository
+// even when Claude Code launches the status line from elsewhere.
+type Repo struct {
+	Dir string
+}
+
+// run executes `git args...` in the repo directory and returns trimmed stdout.
+// The bool is false on any failure (not a repo, git missing, timeout).
+func (r Repo) run(args ...string) (string, bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), gitTimeout)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--abbrev-ref", "HEAD")
+	cmd := exec.CommandContext(ctx, "git", args...)
+	if r.Dir != "" {
+		cmd.Dir = r.Dir
+	}
 	out, err := cmd.Output()
 	if err != nil {
-		return ""
+		return "", false
 	}
-	return strings.TrimSpace(string(out))
+	return strings.TrimSpace(string(out)), true
+}
+
+// Branch returns the current git branch name, or empty string if not in a git repository.
+func (r Repo) Branch() string {
+	out, _ := r.run("rev-parse", "--abbrev-ref", "HEAD")
+	return out
 }

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,0 +1,86 @@
+package git
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// isolateGit points HOME/XDG and git's config vars at throwaway locations so
+// neither the host's global config nor its global ignore file (which can hide
+// the scratch repo's files) affects the test. It applies to both the gitExec
+// setup commands and the production Repo.run calls, which inherit os.Environ.
+func isolateGit(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))
+	t.Setenv("GIT_CONFIG_GLOBAL", filepath.Join(home, "nonexistent-gitconfig"))
+	t.Setenv("GIT_CONFIG_SYSTEM", filepath.Join(home, "nonexistent-gitconfig"))
+	t.Setenv("GIT_AUTHOR_NAME", "test")
+	t.Setenv("GIT_AUTHOR_EMAIL", "test@example.com")
+	t.Setenv("GIT_COMMITTER_NAME", "test")
+	t.Setenv("GIT_COMMITTER_EMAIL", "test@example.com")
+}
+
+func gitExec(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.CommandContext(context.Background(), "git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "git %v: %s", args, out)
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+}
+
+func TestRepoAgainstScratchRepo(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	isolateGit(t)
+
+	dir := t.TempDir()
+	gitExec(t, dir, "init", "-q")
+	writeFile(t, filepath.Join(dir, "README.md"), "line1\n")
+	gitExec(t, dir, "add", "README.md")
+	gitExec(t, dir, "commit", "-q", "-m", "init")
+	gitExec(t, dir, "branch", "-M", "main")
+
+	repo := Repo{Dir: dir}
+
+	t.Run("Branch", func(t *testing.T) {
+		assert.Equal(t, "main", repo.Branch())
+	})
+
+	t.Run("clean tree", func(t *testing.T) {
+		assert.Equal(t, 0, repo.Changes())
+		assert.Equal(t, DiffStat{}, repo.Diff())
+		assert.Empty(t, repo.Worktree())
+	})
+
+	t.Run("modified and untracked", func(t *testing.T) {
+		writeFile(t, filepath.Join(dir, "README.md"), "line1\nline2\nline3\n")
+		writeFile(t, filepath.Join(dir, "extra.txt"), "new\n")
+		assert.Equal(t, 2, repo.Changes()) // one modified, one untracked
+		assert.Equal(t, DiffStat{Added: 2}, repo.Diff())
+	})
+
+	t.Run("Dir, not process cwd, selects the repo", func(t *testing.T) {
+		assert.Empty(t, Repo{Dir: t.TempDir()}.Branch())
+	})
+
+	t.Run("linked worktree", func(t *testing.T) {
+		wtPath := filepath.Join(t.TempDir(), "wt")
+		gitExec(t, dir, "worktree", "add", "-q", "-b", "feature", wtPath)
+		assert.Equal(t, "wt", Repo{Dir: wtPath}.Worktree())
+		assert.Equal(t, "feature", Repo{Dir: wtPath}.Branch())
+	})
+}

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -1,37 +1,26 @@
 package git
 
 import (
-	"context"
-	"os/exec"
 	"path/filepath"
-	"strings"
 )
 
 // Worktree returns the worktree name if the current directory is a git worktree.
 // Returns empty string if in the main working tree or not in a git repository.
-func Worktree() string {
-	ctx, cancel := context.WithTimeout(context.Background(), gitTimeout)
-	defer cancel()
-
-	// Check if we are in a linked worktree.
-	// For linked worktrees, --git-dir returns something like:
+func (r Repo) Worktree() string {
+	// For linked worktrees, --absolute-git-dir returns something like:
 	//   /path/to/main/.git/worktrees/<name>
-	// For the main worktree, it returns:
-	//   /path/to/repo/.git
-	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--git-dir")
-	out, err := cmd.Output()
-	if err != nil {
+	// For the main worktree, it returns the repo's /path/to/repo/.git.
+	// --absolute-git-dir (vs --git-dir) guarantees an absolute path regardless
+	// of the directory git runs in, so detection works when Repo.Dir is set.
+	gitDir, ok := r.run("rev-parse", "--absolute-git-dir")
+	if !ok {
 		return ""
 	}
 
-	gitDir := strings.TrimSpace(string(out))
-
-	// Check if this is a linked worktree by looking for /worktrees/ in the path.
 	dir, name := filepath.Split(gitDir)
 	dir = filepath.Clean(dir)
 	if filepath.Base(dir) == "worktrees" && name != "" {
 		return name
 	}
-
 	return ""
 }

--- a/internal/jsonl/reader.go
+++ b/internal/jsonl/reader.go
@@ -9,6 +9,11 @@ import (
 	"time"
 )
 
+// maxLineBytes bounds the first transcript line the scanner will read. The
+// default bufio.Scanner cap is 64KB, which a large first record (pasted/tool/
+// image payload) can exceed, silently yielding no timestamp.
+const maxLineBytes = 1 << 20 // 1 MiB
+
 // entry represents the minimal fields we need from a JSONL transcript entry.
 type entry struct {
 	Timestamp string `json:"timestamp"`
@@ -27,6 +32,7 @@ func SessionStart(path string) time.Time {
 	defer f.Close()
 
 	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), maxLineBytes)
 	if !scanner.Scan() {
 		return time.Time{}
 	}

--- a/internal/jsonl/reader_test.go
+++ b/internal/jsonl/reader_test.go
@@ -2,6 +2,7 @@ package jsonl
 
 import (
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -100,5 +101,20 @@ func TestSessionStart(t *testing.T) {
 	t.Run("empty path returns zero", func(t *testing.T) {
 		result := SessionStart("")
 		assert.True(t, result.IsZero())
+	})
+
+	t.Run("first line larger than 64KB still parses", func(t *testing.T) {
+		f, err := os.CreateTemp(t.TempDir(), "large-*.jsonl")
+		require.NoError(t, err)
+
+		// Exceed bufio.Scanner's default 64KB cap with a big first record.
+		big := strings.Repeat("x", 70*1024)
+		_, err = f.WriteString(`{"timestamp":"2026-01-15T10:30:00Z","payload":"` + big + `"}` + "\n")
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		result := SessionStart(f.Name())
+		require.False(t, result.IsZero(), "large first line should still yield a timestamp")
+		assert.Equal(t, 2026, result.Year())
 	})
 }

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -17,6 +17,8 @@ const (
 	flexFullPadding = 10
 	// flexCompactPadding is the padding subtracted in "full-minus-40" mode and compact state.
 	flexCompactPadding = 40
+	// minFlexWidth is the floor for the resolved width so truncation always runs.
+	minFlexWidth = 1
 )
 
 // segment holds a rendered widget's text and metadata for the pipeline.
@@ -67,63 +69,82 @@ func PostProcess(line string) string {
 }
 
 // CalculateFlexWidth resolves the available terminal width based on flex mode.
+// The result is clamped to a positive minimum: a non-positive width would make
+// RenderLine skip truncation entirely (its guard is width > 0), letting the line
+// overflow — strictly worse than a narrow-but-bounded width.
 func CalculateFlexWidth(detected int, flexMode string, compactThreshold int, contextPct float64) int {
+	var width int
 	switch flexMode {
 	case "full":
-		return detected - flexFullPadding
+		width = detected - flexFullPadding
 	case "full-minus-40":
-		return detected - flexCompactPadding
+		width = detected - flexCompactPadding
 	case "full-until-compact":
 		if contextPct >= float64(compactThreshold) {
-			return detected - flexCompactPadding
+			width = detected - flexCompactPadding
+		} else {
+			width = detected - flexFullPadding
 		}
-		return detected - flexFullPadding
+	default:
+		return detected
 	}
-	return detected
+	return max(width, minFlexWidth)
 }
 
-// joinWithFlex joins colored segments with padding, expanding flex separators.
+// joinWithFlex joins colored segments, expanding every flex separator. With N
+// flex separators the row splits into N+1 groups; the leftover terminal width is
+// spread evenly across the N gaps so a left/center/right layout aligns correctly.
 func joinWithFlex(colored []string, segments []segment, settings *config.Settings, ctx widget.RenderContext) string {
-	flexIdx := -1
-	for i, seg := range segments {
-		if seg.item.Type == flexSeparatorType {
-			flexIdx = i
-			break
+	var flexIdx []int
+	for i := range segments {
+		if segments[i].item.Type == flexSeparatorType {
+			flexIdx = append(flexIdx, i)
 		}
 	}
-
-	if flexIdx < 0 {
+	if len(flexIdx) == 0 {
 		return strings.Join(colored, settings.DefaultPadding)
 	}
 
-	// Build left and right parts around the flex separator
-	left := strings.Join(colored[:flexIdx], settings.DefaultPadding)
-	right := ""
-	if flexIdx+1 < len(colored) {
-		right = strings.Join(colored[flexIdx+1:], settings.DefaultPadding)
+	// Split into the groups between flex separators, each padding-joined.
+	groups := make([]string, 0, len(flexIdx)+1)
+	prev := 0
+	for _, idx := range flexIdx {
+		groups = append(groups, strings.Join(colored[prev:idx], settings.DefaultPadding))
+		prev = idx + 1
 	}
+	groups = append(groups, strings.Join(colored[prev:], settings.DefaultPadding))
+	gaps := len(flexIdx)
 
 	totalWidth := ctx.TerminalWidth
 	if totalWidth <= 0 {
-		// No terminal width: fall back to single space
-		return joinParts(left, right, " ")
+		// Unknown width: collapse each gap to a single space.
+		return strings.Join(groups, " ")
 	}
 
-	usedWidth := color.VisibleWidth(left) + color.VisibleWidth(right)
-	flexWidth := totalWidth - usedWidth
-	if flexWidth <= 0 {
-		return joinParts(left, right, "")
+	used := 0
+	for _, g := range groups {
+		used += color.VisibleWidth(g)
+	}
+	free := totalWidth - used
+	if free <= 0 {
+		// No room to expand: butt the groups together.
+		return strings.Join(groups, "")
 	}
 
-	return joinParts(left, right, strings.Repeat(" ", flexWidth))
-}
-
-// joinParts concatenates left, filler, and right, omitting empty parts.
-func joinParts(left, right, filler string) string {
+	// Distribute free width across the gaps; spread the remainder over the
+	// leading gaps so the line fills exactly to totalWidth.
+	base, extra := free/gaps, free%gaps
 	var b strings.Builder
-	b.WriteString(left)
-	b.WriteString(filler)
-	b.WriteString(right)
+	for i, g := range groups {
+		b.WriteString(g)
+		if i < gaps {
+			w := base
+			if i < extra {
+				w++
+			}
+			b.WriteString(strings.Repeat(" ", w))
+		}
+	}
 	return b.String()
 }
 
@@ -139,13 +160,11 @@ func renderWidgets(items []config.WidgetItem, ctx widget.RenderContext, settings
 		if text != "" {
 			prefix := items[i].Prefix
 			suffix := items[i].Suffix
-			if p, ok := w.(widget.Prefixer); ok {
-				if prefix == "" {
-					prefix = p.DefaultPrefix()
-				}
-				if suffix == "" {
-					suffix = p.DefaultSuffix()
-				}
+			if prefix == "" {
+				prefix = w.DefaultPrefix()
+			}
+			if suffix == "" {
+				suffix = w.DefaultSuffix()
 			}
 			text = prefix + text + suffix
 		}

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -243,6 +243,28 @@ func TestRenderLine(t *testing.T) {
 				assert.Equal(t, "L R", result)
 			},
 		},
+		{
+			name: "two flex separators both expand (left/center/right)",
+			items: []config.WidgetItem{
+				{ID: "1", Type: "custom-text", CustomText: "L"},
+				{ID: "2", Type: "flex-separator"},
+				{ID: "3", Type: "custom-text", CustomText: "M"},
+				{ID: "4", Type: "flex-separator"},
+				{ID: "5", Type: "custom-text", CustomText: "R"},
+			},
+			settings:      config.Settings{ColorLevel: 0, DefaultPadding: " "},
+			data:          &status.Session{},
+			terminalWidth: 21,
+			check: func(t *testing.T, result string) {
+				t.Helper()
+				// width 21, content "LMR" (3) => 18 free split evenly: 9 + 9.
+				assert.Equal(t, 21, color.VisibleWidth(result))
+				assert.Len(t, result, 21) // no ANSI at colorLevel 0
+				assert.Equal(t, byte('L'), result[0])
+				assert.Equal(t, byte('M'), result[10])
+				assert.Equal(t, byte('R'), result[20])
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -371,6 +393,8 @@ func TestCalculateFlexWidth(t *testing.T) {
 		{"full-until-compact above threshold", 100, "full-until-compact", 60, 80, 60},
 		{"unknown mode returns detected", 100, "unknown", 60, 0, 100},
 		{"empty mode returns detected", 100, "", 60, 0, 100},
+		{"clamps to minimum when padding exceeds width", 30, "full-minus-40", 60, 0, minFlexWidth},
+		{"clamps small full width to minimum", 8, "full", 60, 0, minFlexWidth},
 	}
 
 	for _, tt := range tests {

--- a/internal/render/truncate.go
+++ b/internal/render/truncate.go
@@ -9,56 +9,48 @@ import (
 
 const truncSuffix = "..."
 
-// Truncate shortens a line to fit within maxWidth visible characters.
-// ANSI escape sequences are preserved in the output but do not count toward width.
-// A "..." suffix is appended when truncation occurs.
+// Truncate shortens a line to fit within maxWidth display columns. ANSI escape
+// sequences are preserved in the output but do not count toward width; wide
+// runes count as 2 cells. A "..." suffix is appended when truncation occurs.
 func Truncate(line string, maxWidth int) string {
 	if maxWidth <= 0 {
 		return ""
 	}
 
-	visible := color.VisibleWidth(line)
-	if visible <= maxWidth {
+	if color.VisibleWidth(line) <= maxWidth {
 		return line
 	}
 
-	suffixWidth := utf8.RuneCountInString(truncSuffix)
+	suffixWidth := color.VisibleWidth(truncSuffix)
 	target := maxWidth - suffixWidth
 	if target <= 0 {
 		return truncSuffix[:maxWidth]
 	}
 
-	var result strings.Builder
-	result.Grow(len(line))
-	visCount := 0
+	var b strings.Builder
+	b.Grow(len(line))
+	width := 0
 	i := 0
-	for i < len(line) && visCount < target {
-		// Skip ANSI escape sequences
-		if i+1 < len(line) && line[i] == '\x1b' && line[i+1] == '[' {
-			j := i + 2
-			for j < len(line) && !isTerminator(line[j]) {
-				j++
-			}
-			if j < len(line) {
-				j++
-			}
-			result.WriteString(line[i:j])
+	for i < len(line) {
+		// Copy escape sequences through without counting their width.
+		if line[i] == '\x1b' {
+			j := color.ScanEscape(line, i)
+			b.WriteString(line[i:j])
 			i = j
 			continue
 		}
-		// Copy one rune
-		_, size := utf8.DecodeRuneInString(line[i:])
-		result.WriteString(line[i : i+size])
-		visCount++
+		r, size := utf8.DecodeRuneInString(line[i:])
+		rw := color.RuneWidth(r)
+		if width+rw > target {
+			break
+		}
+		b.WriteString(line[i : i+size])
+		width += rw
 		i += size
 	}
 
-	// Reset colors before suffix
-	result.WriteString("\x1b[0m")
-	result.WriteString(truncSuffix)
-	return result.String()
-}
-
-func isTerminator(b byte) bool {
-	return (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z')
+	// Reset colors before the suffix.
+	b.WriteString("\x1b[0m")
+	b.WriteString(truncSuffix)
+	return b.String()
 }

--- a/internal/status/format.go
+++ b/internal/status/format.go
@@ -2,13 +2,19 @@ package status
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 )
 
 const (
-	defaultMaxTokens   = 200_000
-	defaultUsableRatio = 80 // 80% of max
+	defaultMaxTokens = 200_000
+	// defaultUsableRatio is the share of the window treated as comfortably
+	// usable before auto-compact pressure sets in near the limit. It is a
+	// ccstatus heuristic for the opt-in context-percentage-usable widget, not a
+	// value from the official spec (which exposes only the full-window
+	// used_percentage and the fixed-200k exceeds_200k_tokens).
+	defaultUsableRatio = 80
 	longMaxTokens      = 1_000_000
 )
 
@@ -19,15 +25,22 @@ type WindowLimits struct {
 }
 
 // FormatTokens formats a token count into a human-readable string.
-// Examples: 500 -> "500", 1500 -> "1.5k", 1200000 -> "1.2M"
+// Examples: 500 -> "500", 1500 -> "1.5k", 1200000 -> "1.2M".
+// Rounding is applied before the unit is chosen, so values just under a boundary
+// (e.g. 999_950) read as "1.0M" rather than a stale "1000.0k".
 func FormatTokens(count int) string {
-	if count >= 1_000_000 {
+	switch {
+	case count >= 1_000_000:
 		return fmt.Sprintf("%.1fM", float64(count)/1_000_000)
-	}
-	if count >= 1000 {
+	case count >= 1000:
+		// Round to the 0.1k that %.1f will display; if it reaches 1000.0k, promote to M.
+		if math.Round(float64(count)/100)/10 >= 1000 {
+			return fmt.Sprintf("%.1fM", float64(count)/1_000_000)
+		}
 		return fmt.Sprintf("%.1fk", float64(count)/1000)
+	default:
+		return strconv.Itoa(count)
 	}
-	return strconv.Itoa(count)
 }
 
 // ContextConfig resolves context window size.
@@ -42,8 +55,10 @@ func ContextConfig(data *Session) WindowLimits {
 		}
 	}
 
-	lower := strings.ToLower(data.Model.ID)
-	if strings.Contains(lower, "claude-sonnet-4-5") && strings.Contains(lower, "[1m]") {
+	// Fallback for older Claude Code that omits context_window_size: the "[1m]"
+	// model-id suffix marks an extended (1M) window for any model family, e.g.
+	// claude-sonnet-4-5[1m] or claude-opus-4-8[1m].
+	if strings.Contains(strings.ToLower(data.Model.ID), "[1m]") {
 		return WindowLimits{
 			MaxTokens:    longMaxTokens,
 			UsableTokens: longMaxTokens * defaultUsableRatio / 100,
@@ -100,21 +115,34 @@ func RemainingPercentage(data *Session) (float64, bool) {
 
 // CacheHitRate returns the cache read ratio as a percentage.
 // Formula: cache_read_input_tokens / (input_tokens + cache_creation_input_tokens + cache_read_input_tokens) * 100
-// Returns (value, ok) where ok=false means no data available (total tokens is 0).
+// It needs the per-component current_usage breakdown, so it returns ok=false
+// when current_usage is absent (e.g. just after /compact) or the total is 0.
 func CacheHitRate(data *Session) (float64, bool) {
-	total := ContextLength(data)
+	if data.ContextWindow == nil || data.ContextWindow.CurrentUsage == nil {
+		return 0, false
+	}
+	cu := data.ContextWindow.CurrentUsage
+	total := cu.InputTokens + cu.CacheCreationInputTokens + cu.CacheReadInputTokens
 	if total == 0 {
 		return 0, false
 	}
-	return float64(data.ContextWindow.CurrentUsage.CacheReadInputTokens) / float64(total) * 100, true
+	return float64(cu.CacheReadInputTokens) / float64(total) * 100, true
 }
 
-// ContextLength returns the total input token count (context length).
-// This is the sum of input_tokens + cache_creation_input_tokens + cache_read_input_tokens.
+// ContextLength returns the total input token count (context length): the sum of
+// input_tokens + cache_creation_input_tokens + cache_read_input_tokens.
+// When current_usage is null (e.g. just after /compact, until the next API call)
+// it falls back to total_input_tokens, which the spec defines as the same sum,
+// so the value does not blank out mid-session.
 func ContextLength(data *Session) int {
-	if data.ContextWindow == nil || data.ContextWindow.CurrentUsage == nil {
+	if data.ContextWindow == nil {
 		return 0
 	}
-	cu := data.ContextWindow.CurrentUsage
-	return cu.InputTokens + cu.CacheCreationInputTokens + cu.CacheReadInputTokens
+	if cu := data.ContextWindow.CurrentUsage; cu != nil {
+		return cu.InputTokens + cu.CacheCreationInputTokens + cu.CacheReadInputTokens
+	}
+	if data.ContextWindow.TotalInputTokens != nil {
+		return *data.ContextWindow.TotalInputTokens
+	}
+	return 0
 }

--- a/internal/status/format_test.go
+++ b/internal/status/format_test.go
@@ -17,6 +17,8 @@ func TestFormatTokens(t *testing.T) {
 		{"exact thousand", 1000, "1.0k"},
 		{"thousands", 1500, "1.5k"},
 		{"large thousands", 50000, "50.0k"},
+		{"just below unit boundary stays k", 999_949, "999.9k"},
+		{"rounds up across unit boundary to M", 999_950, "1.0M"},
 		{"exact million", 1_000_000, "1.0M"},
 		{"millions", 1_200_000, "1.2M"},
 	}
@@ -58,6 +60,18 @@ func TestContextConfig(t *testing.T) {
 			data:       &Session{Model: ModelField{ID: "claude-sonnet-4-5"}},
 			wantMax:    200_000,
 			wantUsable: 160_000,
+		},
+		{
+			name:       "[1m] suffix fallback is 1M for any family (opus)",
+			data:       &Session{Model: ModelField{ID: "claude-opus-4-8[1m]"}},
+			wantMax:    1_000_000,
+			wantUsable: 800_000,
+		},
+		{
+			name:       "[1m] suffix fallback is 1M (sonnet)",
+			data:       &Session{Model: ModelField{ID: "claude-sonnet-4-5[1m]"}},
+			wantMax:    1_000_000,
+			wantUsable: 800_000,
 		},
 		{
 			name:       "empty data defaults",
@@ -265,6 +279,8 @@ func TestCacheHitRate(t *testing.T) {
 }
 
 func TestContextLength(t *testing.T) {
+	intPtr := func(v int) *int { return &v }
+
 	tests := []struct {
 		name string
 		data *Session
@@ -284,12 +300,19 @@ func TestContextLength(t *testing.T) {
 			want: 15_000,
 		},
 		{
+			name: "falls back to total_input_tokens after /compact (current_usage null)",
+			data: &Session{
+				ContextWindow: &ContextWindow{TotalInputTokens: intPtr(42_000)},
+			},
+			want: 42_000,
+		},
+		{
 			name: "nil context window",
 			data: &Session{},
 			want: 0,
 		},
 		{
-			name: "nil current usage",
+			name: "nil current usage and no total_input_tokens",
 			data: &Session{ContextWindow: &ContextWindow{}},
 			want: 0,
 		},

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -26,6 +26,7 @@ type Session struct {
 	Vim            *VimInfo       `json:"vim,omitempty"`
 	Agent          *AgentInfo     `json:"agent,omitempty"`
 	Worktree       *WorktreeInfo  `json:"worktree,omitempty"`
+	PR             *PRInfo        `json:"pr,omitempty"`
 }
 
 // Parse parses JSON data into Session.
@@ -35,6 +36,26 @@ func Parse(data []byte) (*Session, error) {
 		return nil, err
 	}
 	return &s, nil
+}
+
+// WorkingDir returns the directory git and path widgets should operate in,
+// mirroring the upstream resolution order: workspace.current_dir, then cwd,
+// then workspace.project_dir. Empty when none are set, so callers fall back to
+// the process working directory.
+func (s *Session) WorkingDir() string {
+	if s == nil {
+		return ""
+	}
+	if s.Workspace != nil && s.Workspace.CurrentDir != "" {
+		return s.Workspace.CurrentDir
+	}
+	if s.Cwd != "" {
+		return s.Cwd
+	}
+	if s.Workspace != nil && s.Workspace.ProjectDir != "" {
+		return s.Workspace.ProjectDir
+	}
+	return ""
 }
 
 // ModelField handles the model field being either a string or an object.
@@ -97,6 +118,25 @@ type Workspace struct {
 	ProjectDir  string   `json:"project_dir,omitempty"`
 	AddedDirs   []string `json:"added_dirs,omitempty"`
 	GitWorktree string   `json:"git_worktree,omitempty"`
+	Repo        *Repo    `json:"repo,omitempty"`
+}
+
+// Repo holds repository identity parsed from the origin remote (for example
+// host "github.com", owner "anthropics", name "claude-code"). Absent outside a
+// git repository or when no origin remote is configured.
+type Repo struct {
+	Host  string `json:"host,omitempty"`
+	Owner string `json:"owner,omitempty"`
+	Name  string `json:"name,omitempty"`
+}
+
+// PRInfo holds the open pull request for the current branch. Absent until a PR
+// is found and removed once it merges or closes. ReviewState may be
+// independently absent even when PRInfo is present.
+type PRInfo struct {
+	Number      *int   `json:"number,omitempty"`
+	URL         string `json:"url,omitempty"`
+	ReviewState string `json:"review_state,omitempty"` // approved | pending | changes_requested | draft
 }
 
 // OutputStyle holds the output style configuration.
@@ -161,8 +201,10 @@ type EffortInfo struct {
 }
 
 // ThinkingInfo indicates whether extended thinking is enabled for the session.
+// Enabled has no omitempty so an explicit false survives a round-trip (the spec
+// treats thinking.enabled as a meaningful, always-present bool).
 type ThinkingInfo struct {
-	Enabled bool `json:"enabled,omitempty"`
+	Enabled bool `json:"enabled"`
 }
 
 // RateLimits holds Claude.ai subscription rate-limit windows. Present only for

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -106,6 +106,35 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
+			name:  "pr and workspace.repo",
+			input: `{"workspace":{"repo":{"host":"github.com","owner":"anthropics","name":"claude-code"}},"pr":{"number":1234,"url":"https://github.com/anthropics/claude-code/pull/1234","review_state":"approved"}}`,
+			check: func(t *testing.T, s *Session) {
+				t.Helper()
+				require.NotNil(t, s.Workspace)
+				require.NotNil(t, s.Workspace.Repo)
+				assert.Equal(t, "github.com", s.Workspace.Repo.Host)
+				assert.Equal(t, "anthropics", s.Workspace.Repo.Owner)
+				assert.Equal(t, "claude-code", s.Workspace.Repo.Name)
+
+				require.NotNil(t, s.PR)
+				require.NotNil(t, s.PR.Number)
+				assert.Equal(t, 1234, *s.PR.Number)
+				assert.Equal(t, "https://github.com/anthropics/claude-code/pull/1234", s.PR.URL)
+				assert.Equal(t, "approved", s.PR.ReviewState)
+			},
+		},
+		{
+			name:  "pr present but review_state independently absent",
+			input: `{"pr":{"number":7}}`,
+			check: func(t *testing.T, s *Session) {
+				t.Helper()
+				require.NotNil(t, s.PR)
+				require.NotNil(t, s.PR.Number)
+				assert.Equal(t, 7, *s.PR.Number)
+				assert.Empty(t, s.PR.ReviewState)
+			},
+		},
+		{
 			name:  "empty JSON object",
 			input: `{}`,
 			check: func(t *testing.T, s *Session) {
@@ -118,6 +147,7 @@ func TestParse(t *testing.T) {
 				assert.Nil(t, s.Effort)
 				assert.Nil(t, s.Thinking)
 				assert.Nil(t, s.RateLimits)
+				assert.Nil(t, s.PR)
 			},
 		},
 		{
@@ -151,6 +181,14 @@ func TestParse(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestThinkingEnabledRoundTrips(t *testing.T) {
+	// enabled has no omitempty, so an explicit false survives marshaling and a
+	// re-serialized session does not lose "thinking explicitly off".
+	data, err := json.Marshal(&Session{Thinking: &ThinkingInfo{Enabled: false}})
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"enabled":false`)
 }
 
 func TestModelField_MarshalJSON(t *testing.T) {

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -24,38 +24,49 @@ const (
 
 // Width returns the terminal width in columns.
 //
-// If override > 0 it wins (the `terminalWidth` setting; use it when running
-// under a host like Claude Code that pipes stdio and may run the status line
-// command detached from the terminal). Otherwise the detection order is:
-// stdout fd, stderr fd, /dev/tty, the controlling terminal of an ancestor
-// process, the COLUMNS env var, then the default 80.
+// If override > 0 it wins (the `terminalWidth` setting). Otherwise the order is:
+//  1. COLUMNS env var — authoritative under the v2.1.153+ status line spec,
+//     which captures the command's output (so the fds are not a terminal) and
+//     sets COLUMNS/LINES to the live dimensions before each run. Costs no
+//     subprocess and is re-set every invocation, so it is not stale.
+//  2. stdout/stderr fd — direct CLI use, and Claude Code versions before the
+//     COLUMNS contract.
+//  3. /dev/tty — our own controlling terminal, if not detached from it.
+//  4. an ancestor process's controlling terminal — last resort that spawns
+//     `ps`, reached only when everything above failed.
+//  5. the default 80.
 func Width(override int) int {
 	if override > 0 {
 		return override
 	}
-	// 1. A standard fd that happens to be a real terminal.
+	if w := widthFromColumns(); w > 0 {
+		return w
+	}
 	for _, f := range []*os.File{os.Stdout, os.Stderr} {
 		if w, _, err := term.GetSize(int(f.Fd())); err == nil && w > 0 { //nolint:gosec // fd values are small, no overflow risk
 			return w
 		}
 	}
-	// 2. Our own controlling terminal (works unless we were detached from it).
 	if w := widthFromTTYPath("/dev/tty"); w > 0 {
 		return w
 	}
-	// 3. The controlling terminal of an ancestor process. This recovers the
-	//    real width when the host ran the status line command detached from
-	//    the terminal (so /dev/tty fails) but an ancestor still owns the tty.
 	if w := widthFromAncestorTTY(); w > 0 {
 		return w
 	}
-	// 4. The COLUMNS env var (captured at spawn time, so it can be stale).
-	if cols := os.Getenv("COLUMNS"); cols != "" {
-		if n, err := strconv.Atoi(cols); err == nil && n > 0 {
-			return n
-		}
-	}
 	return defaultWidth
+}
+
+// widthFromColumns parses the COLUMNS environment variable, returning 0 when it
+// is unset or not a positive integer.
+func widthFromColumns() int {
+	cols := os.Getenv("COLUMNS")
+	if cols == "" {
+		return 0
+	}
+	if n, err := strconv.Atoi(cols); err == nil && n > 0 {
+		return n
+	}
+	return 0
 }
 
 // widthFromTTYPath opens a tty device path and returns its width, or 0.

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -22,6 +22,34 @@ func TestWidth(t *testing.T) {
 		assert.Positive(t, Width(0))
 		assert.Positive(t, Width(-5))
 	})
+
+	t.Run("COLUMNS is honored before fd/tty fallbacks", func(t *testing.T) {
+		t.Setenv("COLUMNS", "123")
+		assert.Equal(t, 123, Width(0))
+	})
+
+	t.Run("override still beats COLUMNS", func(t *testing.T) {
+		t.Setenv("COLUMNS", "123")
+		assert.Equal(t, 200, Width(200))
+	})
+
+	t.Run("invalid COLUMNS falls through to a positive width", func(t *testing.T) {
+		t.Setenv("COLUMNS", "not-a-number")
+		assert.Positive(t, Width(0))
+	})
+}
+
+func TestWidthFromColumns(t *testing.T) {
+	t.Run("positive integer", func(t *testing.T) {
+		t.Setenv("COLUMNS", "80")
+		assert.Equal(t, 80, widthFromColumns())
+	})
+	for _, v := range []string{"", "0", "-3", "abc"} {
+		t.Run("ignores "+v, func(t *testing.T) {
+			t.Setenv("COLUMNS", v)
+			assert.Zero(t, widthFromColumns())
+		})
+	}
 }
 
 func TestWidthFromTTYName(t *testing.T) {

--- a/internal/widget/added_dirs.go
+++ b/internal/widget/added_dirs.go
@@ -11,7 +11,7 @@ import (
 // AddedDirsWidget displays directories added via /add-dir or --add-dir.
 // Default: "+N" (the count). With metadata["display"]="list", shows the joined
 // basenames. Renders empty when no directories have been added.
-type AddedDirsWidget struct{}
+type AddedDirsWidget struct{ noAffix }
 
 // Render returns the added-directories display, or empty if none.
 func (w *AddedDirsWidget) Render(item *config.WidgetItem, ctx RenderContext, _ *config.Settings) string {

--- a/internal/widget/context_percentage_usable.go
+++ b/internal/widget/context_percentage_usable.go
@@ -41,7 +41,7 @@ func (w *ContextPercentageUsableWidget) DisplayName() string { return "Context %
 
 // Description returns what this widget shows.
 func (w *ContextPercentageUsableWidget) Description() string {
-	return "Context usage as percentage of usable window (80% of max)"
+	return "Context usage as % of the usable window (heuristic: 80% of max, leaving auto-compact headroom)"
 }
 
 // SupportsRawValue returns true; raw value omits the % suffix.

--- a/internal/widget/current_dir.go
+++ b/internal/widget/current_dir.go
@@ -9,11 +9,14 @@ import (
 )
 
 // CurrentDirWidget displays the current working directory.
-type CurrentDirWidget struct{}
+type CurrentDirWidget struct{ noAffix }
 
 // Render returns the current directory from the workspace or cwd field.
 // RawValue mode returns the full path with ~ substitution; normal mode returns the base name.
 func (w *CurrentDirWidget) Render(item *config.WidgetItem, ctx RenderContext, _ *config.Settings) string {
+	if ctx.Data == nil {
+		return ""
+	}
 	dir := ""
 	if ctx.Data.Workspace != nil && ctx.Data.Workspace.CurrentDir != "" {
 		dir = ctx.Data.Workspace.CurrentDir

--- a/internal/widget/custom_command.go
+++ b/internal/widget/custom_command.go
@@ -1,19 +1,21 @@
 package widget
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"os/exec"
 	"strings"
 	"time"
 
+	"github.com/moond4rk/ccstatus/internal/color"
 	"github.com/moond4rk/ccstatus/internal/config"
 )
 
 const defaultCommandTimeout = 3 * time.Second
 
 // CustomCommandWidget executes a shell command and displays its output.
-type CustomCommandWidget struct{}
+type CustomCommandWidget struct{ noAffix }
 
 // Render executes the configured command and returns its first line of stdout.
 // The command receives the full JSON session data via stdin.
@@ -33,10 +35,15 @@ func (w *CustomCommandWidget) Render(item *config.WidgetItem, ctx RenderContext,
 
 	cmd := exec.CommandContext(cmdCtx, "sh", "-c", cmdPath)
 
-	// Pipe JSON data to stdin so the command can use it.
-	if ctx.Data != nil {
+	// Forward the exact stdin Claude Code sent so the command sees the full
+	// official schema, including fields ccstatus does not model yet. Only when
+	// the raw bytes are unavailable (e.g. a synthetic RenderContext in tests)
+	// fall back to re-serializing the parsed session, which is necessarily lossy.
+	if len(ctx.RawInput) > 0 {
+		cmd.Stdin = bytes.NewReader(ctx.RawInput)
+	} else if ctx.Data != nil {
 		if data, err := json.Marshal(ctx.Data); err == nil {
-			cmd.Stdin = strings.NewReader(string(data))
+			cmd.Stdin = bytes.NewReader(data)
 		}
 	}
 
@@ -52,41 +59,21 @@ func (w *CustomCommandWidget) Render(item *config.WidgetItem, ctx RenderContext,
 		result = result[:idx]
 	}
 
-	// Apply maxWidth truncation.
-	if item.MaxWidth > 0 && len(result) > item.MaxWidth {
-		result = result[:item.MaxWidth]
+	// Strip ANSI codes unless preserveColors is set, before measuring width so
+	// maxWidth counts visible characters rather than escape bytes.
+	if !item.PreserveColors {
+		result = color.StripANSI(result)
 	}
 
-	// Strip ANSI codes unless preserveColors is set.
-	if !item.PreserveColors {
-		result = stripANSI(result)
+	// Apply maxWidth truncation by runes so multibyte output is never cut
+	// mid-codepoint.
+	if item.MaxWidth > 0 {
+		if runes := []rune(result); len(runes) > item.MaxWidth {
+			result = string(runes[:item.MaxWidth])
+		}
 	}
 
 	return result
-}
-
-// stripANSI removes ANSI escape sequences from a string.
-func stripANSI(s string) string {
-	var b strings.Builder
-	b.Grow(len(s))
-	i := 0
-	for i < len(s) {
-		if s[i] == '\x1b' && i+1 < len(s) && s[i+1] == '[' {
-			// Skip until we find the terminating letter.
-			j := i + 2
-			for j < len(s) && (s[j] < 'A' || s[j] > 'Z') && (s[j] < 'a' || s[j] > 'z') {
-				j++
-			}
-			if j < len(s) {
-				j++ // skip the terminating letter
-			}
-			i = j
-		} else {
-			b.WriteByte(s[i])
-			i++
-		}
-	}
-	return b.String()
 }
 
 // DefaultColor returns the default foreground color.

--- a/internal/widget/custom_text.go
+++ b/internal/widget/custom_text.go
@@ -3,7 +3,7 @@ package widget
 import "github.com/moond4rk/ccstatus/internal/config"
 
 // CustomTextWidget displays user-defined static text.
-type CustomTextWidget struct{}
+type CustomTextWidget struct{ noAffix }
 
 // Render returns the custom text from the widget configuration.
 func (w *CustomTextWidget) Render(item *config.WidgetItem, _ RenderContext, _ *config.Settings) string {

--- a/internal/widget/exceeds_200k.go
+++ b/internal/widget/exceeds_200k.go
@@ -3,7 +3,7 @@ package widget
 import "github.com/moond4rk/ccstatus/internal/config"
 
 // Exceeds200KWidget displays a warning when token count exceeds the 200k threshold.
-type Exceeds200KWidget struct{}
+type Exceeds200KWidget struct{ noAffix }
 
 // Render returns ">200k" if the token count exceeds 200k, empty otherwise.
 func (w *Exceeds200KWidget) Render(_ *config.WidgetItem, ctx RenderContext, _ *config.Settings) string {

--- a/internal/widget/flex_separator.go
+++ b/internal/widget/flex_separator.go
@@ -6,7 +6,7 @@ const flexSeparatorType = "flex-separator"
 
 // FlexSeparatorWidget is a placeholder that expands to fill remaining terminal width.
 // The actual expansion is handled by the render pipeline.
-type FlexSeparatorWidget struct{}
+type FlexSeparatorWidget struct{ noAffix }
 
 // Render returns a sentinel value; the render pipeline replaces it with spaces.
 func (w *FlexSeparatorWidget) Render(_ *config.WidgetItem, _ RenderContext, _ *config.Settings) string {

--- a/internal/widget/git_branch.go
+++ b/internal/widget/git_branch.go
@@ -5,7 +5,7 @@ import (
 )
 
 // GitBranchWidget displays the current git branch name.
-type GitBranchWidget struct{}
+type GitBranchWidget struct{ noAffix }
 
 // Render returns the current git branch, optionally prefixed with a character.
 func (w *GitBranchWidget) Render(item *config.WidgetItem, ctx RenderContext, _ *config.Settings) string {

--- a/internal/widget/git_changes.go
+++ b/internal/widget/git_changes.go
@@ -7,7 +7,7 @@ import (
 )
 
 // GitChangesWidget displays the number of uncommitted changes.
-type GitChangesWidget struct{}
+type GitChangesWidget struct{ noAffix }
 
 // Render returns the uncommitted change count, or empty if there are none.
 func (w *GitChangesWidget) Render(_ *config.WidgetItem, ctx RenderContext, _ *config.Settings) string {

--- a/internal/widget/git_worktree.go
+++ b/internal/widget/git_worktree.go
@@ -5,7 +5,7 @@ import (
 )
 
 // GitWorktreeWidget displays the current git worktree name.
-type GitWorktreeWidget struct{}
+type GitWorktreeWidget struct{ noAffix }
 
 // Render returns the worktree name if in a linked worktree, empty otherwise.
 // Source order: workspace.git_worktree (any linked worktree), worktree.name

--- a/internal/widget/lines_changed.go
+++ b/internal/widget/lines_changed.go
@@ -7,7 +7,7 @@ import (
 )
 
 // LinesChangedWidget displays git diff line additions and deletions.
-type LinesChangedWidget struct{}
+type LinesChangedWidget struct{ noAffix }
 
 // Render returns a "+N/-M" format from git diff --shortstat, or empty if clean.
 func (w *LinesChangedWidget) Render(_ *config.WidgetItem, ctx RenderContext, _ *config.Settings) string {
@@ -33,7 +33,7 @@ func (w *LinesChangedWidget) Description() string {
 func (w *LinesChangedWidget) SupportsRawValue() bool { return false }
 
 // LinesAddedWidget displays only the git diff lines added count.
-type LinesAddedWidget struct{}
+type LinesAddedWidget struct{ noAffix }
 
 // Render returns "+N" from git diff, or empty if zero.
 func (w *LinesAddedWidget) Render(_ *config.WidgetItem, ctx RenderContext, _ *config.Settings) string {
@@ -57,7 +57,7 @@ func (w *LinesAddedWidget) Description() string { return "Uncommitted lines adde
 func (w *LinesAddedWidget) SupportsRawValue() bool { return false }
 
 // LinesRemovedWidget displays only the git diff lines removed count.
-type LinesRemovedWidget struct{}
+type LinesRemovedWidget struct{ noAffix }
 
 // Render returns "-N" from git diff, or empty if zero.
 func (w *LinesRemovedWidget) Render(_ *config.WidgetItem, ctx RenderContext, _ *config.Settings) string {

--- a/internal/widget/model.go
+++ b/internal/widget/model.go
@@ -3,7 +3,7 @@ package widget
 import "github.com/moond4rk/ccstatus/internal/config"
 
 // ModelWidget displays the current Claude model name.
-type ModelWidget struct{}
+type ModelWidget struct{ noAffix }
 
 // Render returns the model display name, or model ID if rawValue is set.
 func (w *ModelWidget) Render(item *config.WidgetItem, ctx RenderContext, _ *config.Settings) string {

--- a/internal/widget/pr.go
+++ b/internal/widget/pr.go
@@ -1,0 +1,41 @@
+package widget
+
+import (
+	"strconv"
+
+	"github.com/moond4rk/ccstatus/internal/config"
+)
+
+// PRWidget displays the open pull request for the current branch (the same data
+// as Claude Code's PR badge).
+type PRWidget struct{ noAffix }
+
+// Render returns "#<number>" plus the review state when present (just the bare
+// number in raw mode), and empty when there is no open PR.
+func (w *PRWidget) Render(item *config.WidgetItem, ctx RenderContext, _ *config.Settings) string {
+	if ctx.Data == nil || ctx.Data.PR == nil || ctx.Data.PR.Number == nil {
+		return ""
+	}
+	pr := ctx.Data.PR
+	number := strconv.Itoa(*pr.Number)
+	if item.RawValue {
+		return number
+	}
+	out := "#" + number
+	if pr.ReviewState != "" {
+		out += " " + pr.ReviewState
+	}
+	return out
+}
+
+// DefaultColor returns the default foreground color.
+func (w *PRWidget) DefaultColor() string { return "cyan" }
+
+// DisplayName returns the human-readable name.
+func (w *PRWidget) DisplayName() string { return "Pull Request" }
+
+// Description returns what this widget shows.
+func (w *PRWidget) Description() string { return "Open PR number and review state" }
+
+// SupportsRawValue returns true (raw mode shows the bare number).
+func (w *PRWidget) SupportsRawValue() bool { return true }

--- a/internal/widget/project_dir.go
+++ b/internal/widget/project_dir.go
@@ -7,7 +7,7 @@ import (
 )
 
 // ProjectDirWidget displays the project root directory.
-type ProjectDirWidget struct{}
+type ProjectDirWidget struct{ noAffix }
 
 // Render returns the project directory from the workspace field.
 // RawValue mode returns the full path with ~ substitution; normal mode returns the base name.

--- a/internal/widget/repo.go
+++ b/internal/widget/repo.go
@@ -1,0 +1,37 @@
+package widget
+
+import (
+	"github.com/moond4rk/ccstatus/internal/config"
+)
+
+// RepoWidget displays the repository identity from workspace.repo (parsed by
+// Claude Code from the origin remote).
+type RepoWidget struct{ noAffix }
+
+// Render returns "owner/name" (or just the name in raw mode, or when no owner is
+// present), and empty when no repo identity is available.
+func (w *RepoWidget) Render(item *config.WidgetItem, ctx RenderContext, _ *config.Settings) string {
+	if ctx.Data == nil || ctx.Data.Workspace == nil || ctx.Data.Workspace.Repo == nil {
+		return ""
+	}
+	repo := ctx.Data.Workspace.Repo
+	if repo.Name == "" {
+		return ""
+	}
+	if item.RawValue || repo.Owner == "" {
+		return repo.Name
+	}
+	return repo.Owner + "/" + repo.Name
+}
+
+// DefaultColor returns the default foreground color.
+func (w *RepoWidget) DefaultColor() string { return "blue" }
+
+// DisplayName returns the human-readable name.
+func (w *RepoWidget) DisplayName() string { return "Repository" }
+
+// Description returns what this widget shows.
+func (w *RepoWidget) Description() string { return "Repository owner/name from the origin remote" }
+
+// SupportsRawValue returns true (raw mode drops the owner prefix).
+func (w *RepoWidget) SupportsRawValue() bool { return true }

--- a/internal/widget/separator.go
+++ b/internal/widget/separator.go
@@ -3,7 +3,7 @@ package widget
 import "github.com/moond4rk/ccstatus/internal/config"
 
 // SeparatorWidget displays a visual separator between other widgets.
-type SeparatorWidget struct{}
+type SeparatorWidget struct{ noAffix }
 
 // Render returns the separator character from the widget config or settings default.
 func (w *SeparatorWidget) Render(item *config.WidgetItem, _ RenderContext, settings *config.Settings) string {

--- a/internal/widget/session_clock.go
+++ b/internal/widget/session_clock.go
@@ -17,7 +17,7 @@ type SessionClockWidget struct{}
 
 // Render returns the session duration in human-readable format.
 func (w *SessionClockWidget) Render(item *config.WidgetItem, ctx RenderContext, _ *config.Settings) string {
-	if ctx.Data.Cost == nil || ctx.Data.Cost.TotalDurationMS == nil {
+	if ctx.Data == nil || ctx.Data.Cost == nil || ctx.Data.Cost.TotalDurationMS == nil {
 		return ""
 	}
 	ms := *ctx.Data.Cost.TotalDurationMS

--- a/internal/widget/session_cost.go
+++ b/internal/widget/session_cost.go
@@ -13,7 +13,7 @@ type SessionCostWidget struct{}
 
 // Render returns the session cost formatted as dollars.
 func (w *SessionCostWidget) Render(item *config.WidgetItem, ctx RenderContext, _ *config.Settings) string {
-	if ctx.Data.Cost == nil || ctx.Data.Cost.TotalCostUSD == nil {
+	if ctx.Data == nil || ctx.Data.Cost == nil || ctx.Data.Cost.TotalCostUSD == nil {
 		return ""
 	}
 	cost := *ctx.Data.Cost.TotalCostUSD

--- a/internal/widget/session_id.go
+++ b/internal/widget/session_id.go
@@ -5,7 +5,7 @@ import "github.com/moond4rk/ccstatus/internal/config"
 const sessionIDShortLen = 8
 
 // SessionIDWidget displays the Claude Code session ID.
-type SessionIDWidget struct{}
+type SessionIDWidget struct{ noAffix }
 
 // Render returns the session ID. Normal mode truncates to 8 characters;
 // rawValue mode returns the full UUID.

--- a/internal/widget/terminal_width.go
+++ b/internal/widget/terminal_width.go
@@ -7,7 +7,7 @@ import (
 )
 
 // TerminalWidthWidget displays the current terminal width in columns.
-type TerminalWidthWidget struct{}
+type TerminalWidthWidget struct{ noAffix }
 
 // Render returns the terminal width as a string.
 func (w *TerminalWidthWidget) Render(_ *config.WidgetItem, ctx RenderContext, _ *config.Settings) string {

--- a/internal/widget/transcript_path.go
+++ b/internal/widget/transcript_path.go
@@ -7,7 +7,7 @@ import (
 )
 
 // TranscriptPathWidget displays the transcript file path.
-type TranscriptPathWidget struct{}
+type TranscriptPathWidget struct{ noAffix }
 
 // Render returns the transcript path.
 // RawValue mode returns the full path with ~ substitution; normal mode returns the base name.

--- a/internal/widget/version.go
+++ b/internal/widget/version.go
@@ -3,7 +3,7 @@ package widget
 import "github.com/moond4rk/ccstatus/internal/config"
 
 // VersionWidget displays the Claude Code version.
-type VersionWidget struct{}
+type VersionWidget struct{ noAffix }
 
 // Render returns the Claude Code version string.
 func (w *VersionWidget) Render(_ *config.WidgetItem, ctx RenderContext, _ *config.Settings) string {

--- a/internal/widget/widget.go
+++ b/internal/widget/widget.go
@@ -13,27 +13,49 @@ type RenderContext struct {
 	Data          *status.Session
 	TerminalWidth int
 	Git           *GitCache
+	// RawInput is the exact stdin Claude Code piped in, forwarded verbatim to
+	// custom commands so they see the full official schema (including fields
+	// ccstatus does not model yet). Nil when unavailable.
+	RawInput []byte
 }
 
-// GitCache caches git command results for a single render cycle.
-// Each accessor lazily invokes the underlying git command at most once.
+// GitProvider supplies git repository facts for one render cycle.
+// git.Repo satisfies it for production; tests inject a deterministic fake.
+type GitProvider interface {
+	Branch() string
+	Changes() int
+	Diff() git.DiffStat
+	Worktree() string
+}
+
+// GitCache memoizes GitProvider results for a single render cycle so each git
+// command runs at most once. A nil cache yields zero values.
 type GitCache struct {
+	provider GitProvider
 	branch   *string
 	changes  *int
 	worktree *string
 	diff     *git.DiffStat
 }
 
-// NewGitCache creates a new empty cache for one render cycle.
-func NewGitCache() *GitCache { return &GitCache{} }
+// NewGitCache creates a cache whose git commands run in dir (empty = the
+// process working directory).
+func NewGitCache(dir string) *GitCache {
+	return &GitCache{provider: git.Repo{Dir: dir}}
+}
+
+// NewGitCacheWithProvider creates a cache backed by a custom provider, for tests.
+func NewGitCacheWithProvider(p GitProvider) *GitCache {
+	return &GitCache{provider: p}
+}
 
 // Branch returns the current git branch, caching the result.
 func (c *GitCache) Branch() string {
-	if c == nil {
-		return git.Branch()
+	if c == nil || c.provider == nil {
+		return ""
 	}
 	if c.branch == nil {
-		b := git.Branch()
+		b := c.provider.Branch()
 		c.branch = &b
 	}
 	return *c.branch
@@ -41,11 +63,11 @@ func (c *GitCache) Branch() string {
 
 // Changes returns the uncommitted change count, caching the result.
 func (c *GitCache) Changes() int {
-	if c == nil {
-		return git.Changes()
+	if c == nil || c.provider == nil {
+		return 0
 	}
 	if c.changes == nil {
-		n := git.Changes()
+		n := c.provider.Changes()
 		c.changes = &n
 	}
 	return *c.changes
@@ -53,11 +75,11 @@ func (c *GitCache) Changes() int {
 
 // Worktree returns the worktree name, caching the result.
 func (c *GitCache) Worktree() string {
-	if c == nil {
-		return git.Worktree()
+	if c == nil || c.provider == nil {
+		return ""
 	}
 	if c.worktree == nil {
-		w := git.Worktree()
+		w := c.provider.Worktree()
 		c.worktree = &w
 	}
 	return *c.worktree
@@ -65,11 +87,11 @@ func (c *GitCache) Worktree() string {
 
 // Diff returns the line-level diff stats, caching the result.
 func (c *GitCache) Diff() git.DiffStat {
-	if c == nil {
-		return git.Diff()
+	if c == nil || c.provider == nil {
+		return git.DiffStat{}
 	}
 	if c.diff == nil {
-		d := git.Diff()
+		d := c.provider.Diff()
 		c.diff = &d
 	}
 	return *c.diff
@@ -92,6 +114,14 @@ type Widget interface {
 
 	// SupportsRawValue indicates if the widget has a compact output mode.
 	SupportsRawValue() bool
+
+	// DefaultPrefix returns text prepended to the output when the user set none.
+	// Embed noAffix to inherit "".
+	DefaultPrefix() string
+
+	// DefaultSuffix returns text appended to the output when the user set none.
+	// Embed noAffix to inherit "".
+	DefaultSuffix() string
 }
 
 var registry = map[string]Widget{
@@ -108,7 +138,9 @@ var registry = map[string]Widget{
 
 	// Token metrics. Since Claude Code v2.1.132 the total_input_tokens /
 	// total_output_tokens fields reflect the current context window, not
-	// cumulative session totals; tokens-input is now ~= context-length.
+	// cumulative session totals. tokens-input and context-length track the same
+	// quantity; context-length also falls back to total_input_tokens when
+	// current_usage is null (e.g. just after /compact), so it does not blank out.
 	"tokens-input": &tokenWidget{
 		extract: extractInputTokens, displayName: "Input Tokens", description: "Input tokens currently in context (includes cache reads/writes)",
 		defaultPrefix: "In: ",
@@ -160,6 +192,8 @@ var registry = map[string]Widget{
 	"project-dir":         &ProjectDirWidget{},
 	"transcript-path":     &TranscriptPathWidget{},
 	"added-dirs":          &AddedDirsWidget{},
+	"repo":                &RepoWidget{},
+	"pr":                  &PRWidget{},
 	"lines-changed":       &LinesChangedWidget{},
 	"lines-added":         &LinesAddedWidget{},
 	"lines-removed":       &LinesRemovedWidget{},
@@ -261,22 +295,17 @@ var registry = map[string]Widget{
 	"flex-separator": &FlexSeparatorWidget{},
 }
 
-// Prefixer is an optional interface for widgets that provide default prefix/suffix.
-// User-configured values in WidgetItem.Prefix/Suffix take precedence over defaults.
-type Prefixer interface {
-	DefaultPrefix() string
-	DefaultSuffix() string
-}
+// noAffix provides empty default prefix/suffix. Embed it in widgets that add no
+// affix of their own, so every Widget satisfies the interface without boilerplate.
+// User-configured WidgetItem.Prefix/Suffix always take precedence over defaults.
+type noAffix struct{}
+
+func (noAffix) DefaultPrefix() string { return "" }
+func (noAffix) DefaultSuffix() string { return "" }
 
 // Get returns the widget for the given type string, or nil if unknown.
 func Get(widgetType string) Widget {
 	return registry[widgetType]
-}
-
-// Register adds a widget to the registry. Used by other packages to register
-// widgets that are implemented outside the base widget package.
-func Register(widgetType string, w Widget) {
-	registry[widgetType] = w
 }
 
 // Types returns all registered widget type names.

--- a/internal/widget/widget_test.go
+++ b/internal/widget/widget_test.go
@@ -4,13 +4,34 @@ import (
 	"os"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/moond4rk/ccstatus/internal/config"
+	"github.com/moond4rk/ccstatus/internal/git"
 	"github.com/moond4rk/ccstatus/internal/status"
 )
+
+// fakeGit is a deterministic GitProvider so git widgets can be asserted exactly
+// without depending on the working tree the test happens to run in.
+type fakeGit struct {
+	branch   string
+	changes  int
+	diff     git.DiffStat
+	worktree string
+}
+
+func (f fakeGit) Branch() string     { return f.branch }
+func (f fakeGit) Changes() int       { return f.changes }
+func (f fakeGit) Diff() git.DiffStat { return f.diff }
+func (f fakeGit) Worktree() string   { return f.worktree }
+
+// gitCtx builds a RenderContext whose git accessors return p's fixed values.
+func gitCtx(p GitProvider) RenderContext {
+	return RenderContext{Data: &status.Session{}, Git: NewGitCacheWithProvider(p)}
+}
 
 func intPtr(v int) *int           { return &v }
 func floatPtr(v float64) *float64 { return &v }
@@ -565,19 +586,54 @@ func TestSessionClockWidget(t *testing.T) {
 	assert.True(t, w.SupportsRawValue())
 }
 
+func TestGitBranchWidget(t *testing.T) {
+	w := &GitBranchWidget{}
+	settings := config.DefaultSettings()
+
+	t.Run("renders branch name", func(t *testing.T) {
+		ctx := gitCtx(fakeGit{branch: "main"})
+		assert.Equal(t, "main", w.Render(&config.WidgetItem{}, ctx, &settings))
+	})
+	t.Run("empty outside a repo", func(t *testing.T) {
+		ctx := gitCtx(fakeGit{})
+		assert.Empty(t, w.Render(&config.WidgetItem{}, ctx, &settings))
+	})
+	t.Run("character prefix", func(t *testing.T) {
+		ctx := gitCtx(fakeGit{branch: "main"})
+		assert.Equal(t, "@ main", w.Render(&config.WidgetItem{Character: "@"}, ctx, &settings))
+	})
+
+	assert.Equal(t, "magenta", w.DefaultColor())
+	assert.True(t, w.SupportsRawValue())
+}
+
+func TestGitChangesWidget(t *testing.T) {
+	w := &GitChangesWidget{}
+	settings := config.DefaultSettings()
+
+	t.Run("renders change count", func(t *testing.T) {
+		ctx := gitCtx(fakeGit{changes: 3})
+		assert.Equal(t, "3", w.Render(&config.WidgetItem{}, ctx, &settings))
+	})
+	t.Run("empty when clean", func(t *testing.T) {
+		ctx := gitCtx(fakeGit{changes: 0})
+		assert.Empty(t, w.Render(&config.WidgetItem{}, ctx, &settings))
+	})
+
+	assert.Equal(t, "yellow", w.DefaultColor())
+}
+
 func TestLinesChangedWidget(t *testing.T) {
 	w := &LinesChangedWidget{}
+	settings := config.DefaultSettings()
 
-	t.Run("returns git diff format or empty", func(t *testing.T) {
-		// Widget calls real git commands; result depends on working tree state.
-		// Verify output is either empty or matches +N/-M format.
-		settings := config.DefaultSettings()
-		item := config.WidgetItem{}
-		ctx := RenderContext{Data: &status.Session{}}
-		result := w.Render(&item, ctx, &settings)
-		if result != "" {
-			assert.Regexp(t, `^\+\d+/-\d+$`, result)
-		}
+	t.Run("renders +N/-M", func(t *testing.T) {
+		ctx := gitCtx(fakeGit{diff: git.DiffStat{Added: 10, Removed: 5}})
+		assert.Equal(t, "+10/-5", w.Render(&config.WidgetItem{}, ctx, &settings))
+	})
+	t.Run("empty when no diff", func(t *testing.T) {
+		ctx := gitCtx(fakeGit{})
+		assert.Empty(t, w.Render(&config.WidgetItem{}, ctx, &settings))
 	})
 
 	assert.Equal(t, "green", w.DefaultColor())
@@ -587,15 +643,15 @@ func TestLinesChangedWidget(t *testing.T) {
 
 func TestLinesAddedWidget(t *testing.T) {
 	w := &LinesAddedWidget{}
+	settings := config.DefaultSettings()
 
-	t.Run("returns git diff format or empty", func(t *testing.T) {
-		settings := config.DefaultSettings()
-		item := config.WidgetItem{}
-		ctx := RenderContext{Data: &status.Session{}}
-		result := w.Render(&item, ctx, &settings)
-		if result != "" {
-			assert.Regexp(t, `^\+\d+$`, result)
-		}
+	t.Run("renders +N", func(t *testing.T) {
+		ctx := gitCtx(fakeGit{diff: git.DiffStat{Added: 7}})
+		assert.Equal(t, "+7", w.Render(&config.WidgetItem{}, ctx, &settings))
+	})
+	t.Run("empty when nothing added", func(t *testing.T) {
+		ctx := gitCtx(fakeGit{diff: git.DiffStat{Removed: 3}})
+		assert.Empty(t, w.Render(&config.WidgetItem{}, ctx, &settings))
 	})
 
 	assert.Equal(t, "green", w.DefaultColor())
@@ -603,18 +659,76 @@ func TestLinesAddedWidget(t *testing.T) {
 
 func TestLinesRemovedWidget(t *testing.T) {
 	w := &LinesRemovedWidget{}
+	settings := config.DefaultSettings()
 
-	t.Run("returns git diff format or empty", func(t *testing.T) {
-		settings := config.DefaultSettings()
-		item := config.WidgetItem{}
-		ctx := RenderContext{Data: &status.Session{}}
-		result := w.Render(&item, ctx, &settings)
-		if result != "" {
-			assert.Regexp(t, `^-\d+$`, result)
-		}
+	t.Run("renders -N", func(t *testing.T) {
+		ctx := gitCtx(fakeGit{diff: git.DiffStat{Removed: 4}})
+		assert.Equal(t, "-4", w.Render(&config.WidgetItem{}, ctx, &settings))
+	})
+	t.Run("empty when nothing removed", func(t *testing.T) {
+		ctx := gitCtx(fakeGit{diff: git.DiffStat{Added: 2}})
+		assert.Empty(t, w.Render(&config.WidgetItem{}, ctx, &settings))
 	})
 
 	assert.Equal(t, "red", w.DefaultColor())
+}
+
+func TestRepoWidget(t *testing.T) {
+	w := &RepoWidget{}
+	settings := config.DefaultSettings()
+	repo := &status.Repo{Host: "github.com", Owner: "anthropics", Name: "claude-code"}
+
+	t.Run("owner/name by default", func(t *testing.T) {
+		ctx := RenderContext{Data: &status.Session{Workspace: &status.Workspace{Repo: repo}}}
+		assert.Equal(t, "anthropics/claude-code", w.Render(&config.WidgetItem{}, ctx, &settings))
+	})
+	t.Run("raw value drops the owner", func(t *testing.T) {
+		ctx := RenderContext{Data: &status.Session{Workspace: &status.Workspace{Repo: repo}}}
+		assert.Equal(t, "claude-code", w.Render(&config.WidgetItem{RawValue: true}, ctx, &settings))
+	})
+	t.Run("name only when no owner", func(t *testing.T) {
+		ctx := RenderContext{Data: &status.Session{Workspace: &status.Workspace{Repo: &status.Repo{Name: "solo"}}}}
+		assert.Equal(t, "solo", w.Render(&config.WidgetItem{}, ctx, &settings))
+	})
+	t.Run("empty when repo absent", func(t *testing.T) {
+		ctx := RenderContext{Data: &status.Session{Workspace: &status.Workspace{}}}
+		assert.Empty(t, w.Render(&config.WidgetItem{}, ctx, &settings))
+	})
+	t.Run("empty when data nil", func(t *testing.T) {
+		assert.Empty(t, w.Render(&config.WidgetItem{}, RenderContext{}, &settings))
+	})
+
+	assert.Equal(t, "blue", w.DefaultColor())
+	assert.True(t, w.SupportsRawValue())
+}
+
+func TestPRWidget(t *testing.T) {
+	w := &PRWidget{}
+	settings := config.DefaultSettings()
+	num := 1234
+
+	t.Run("number and review state", func(t *testing.T) {
+		ctx := RenderContext{Data: &status.Session{PR: &status.PRInfo{Number: &num, ReviewState: "approved"}}}
+		assert.Equal(t, "#1234 approved", w.Render(&config.WidgetItem{}, ctx, &settings))
+	})
+	t.Run("number only when review state absent", func(t *testing.T) {
+		ctx := RenderContext{Data: &status.Session{PR: &status.PRInfo{Number: &num}}}
+		assert.Equal(t, "#1234", w.Render(&config.WidgetItem{}, ctx, &settings))
+	})
+	t.Run("raw value is the bare number", func(t *testing.T) {
+		ctx := RenderContext{Data: &status.Session{PR: &status.PRInfo{Number: &num, ReviewState: "approved"}}}
+		assert.Equal(t, "1234", w.Render(&config.WidgetItem{RawValue: true}, ctx, &settings))
+	})
+	t.Run("empty when no number", func(t *testing.T) {
+		ctx := RenderContext{Data: &status.Session{PR: &status.PRInfo{}}}
+		assert.Empty(t, w.Render(&config.WidgetItem{}, ctx, &settings))
+	})
+	t.Run("empty when pr absent", func(t *testing.T) {
+		assert.Empty(t, w.Render(&config.WidgetItem{}, RenderContext{Data: &status.Session{}}, &settings))
+	})
+
+	assert.Equal(t, "cyan", w.DefaultColor())
+	assert.True(t, w.SupportsRawValue())
 }
 
 func TestTypes(t *testing.T) {
@@ -632,6 +746,8 @@ func TestTypes(t *testing.T) {
 	assert.Contains(t, types, "lines-changed")
 	assert.Contains(t, types, "lines-added")
 	assert.Contains(t, types, "lines-removed")
+	assert.Contains(t, types, "repo")
+	assert.Contains(t, types, "pr")
 	assert.Contains(t, types, "remaining-percentage")
 	assert.Contains(t, types, "cache-hit-rate")
 	assert.Contains(t, types, "api-duration")
@@ -656,7 +772,7 @@ func TestTypes(t *testing.T) {
 	assert.Contains(t, types, "thinking")
 	assert.Contains(t, types, "session-name")
 	assert.Contains(t, types, "added-dirs")
-	assert.Len(t, types, 44)
+	assert.Len(t, types, 46)
 }
 
 func TestRemainingPercentageWidget(t *testing.T) {
@@ -972,21 +1088,6 @@ func TestCurrentUsageTokenWidgets(t *testing.T) {
 	})
 }
 
-func TestRegister(t *testing.T) {
-	original := Get("test-widget")
-	defer func() {
-		if original == nil {
-			delete(registry, "test-widget")
-		} else {
-			registry["test-widget"] = original
-		}
-	}()
-
-	assert.Nil(t, Get("test-widget"))
-	Register("test-widget", &CustomTextWidget{})
-	assert.NotNil(t, Get("test-widget"))
-}
-
 func boolPtr(v bool) *bool    { return &v }
 func int64Ptr(v int64) *int64 { return &v }
 
@@ -1208,6 +1309,16 @@ func TestCustomCommandWidget(t *testing.T) {
 		assert.Equal(t, "long", w.Render(&item, ctx, &settings))
 	})
 
+	t.Run("maxWidth truncates by rune, not byte", func(t *testing.T) {
+		// printf emits "aéb" (é = UTF-8 C3 A9); maxWidth 2 must yield "aé",
+		// never a mid-codepoint byte cut.
+		item := config.WidgetItem{CommandPath: `printf 'a\303\251b'`, MaxWidth: 2}
+		ctx := RenderContext{Data: &status.Session{}}
+		got := w.Render(&item, ctx, &settings)
+		assert.Equal(t, "aé", got)
+		assert.True(t, utf8.ValidString(got))
+	})
+
 	t.Run("strips ANSI by default", func(t *testing.T) {
 		item := config.WidgetItem{CommandPath: `printf '\033[32mgreen\033[0m'`}
 		ctx := RenderContext{Data: &status.Session{}}
@@ -1242,6 +1353,15 @@ func TestCustomCommandWidget(t *testing.T) {
 		// jq may not be installed; accept either the parsed value or fallback.
 		assert.True(t, result == "1.0.80" || result == "fallback",
 			"expected '1.0.80' or 'fallback', got %q", result)
+	})
+
+	t.Run("forwards raw stdin verbatim so unmodeled fields survive", func(t *testing.T) {
+		// A re-serialized Session would drop unknown_future_field and emit
+		// version 1.0.80; forwarding the raw bytes preserves both.
+		raw := `{"version":"9.9.9","unknown_future_field":true}`
+		item := config.WidgetItem{CommandPath: "cat"}
+		ctx := RenderContext{Data: &status.Session{Version: "1.0.80"}, RawInput: []byte(raw)}
+		assert.Equal(t, raw, w.Render(&item, ctx, &settings))
 	})
 
 	assert.Equal(t, "white", w.DefaultColor())
@@ -1401,9 +1521,16 @@ func TestGitWorktreeWidget(t *testing.T) {
 		assert.Equal(t, "wt-tree", w.Render(&item, ctx, &settings))
 	})
 
-	t.Run("nil data falls back to git command without panic", func(t *testing.T) {
+	t.Run("falls back to the git provider", func(t *testing.T) {
+		ctx := RenderContext{Data: &status.Session{}, Git: NewGitCacheWithProvider(fakeGit{worktree: "linked"})}
+		assert.Equal(t, "linked", w.Render(&item, ctx, &settings))
+	})
+
+	t.Run("nil data and nil git: empty, no panic", func(t *testing.T) {
 		ctx := RenderContext{Data: nil}
-		assert.NotPanics(t, func() { w.Render(&item, ctx, &settings) })
+		assert.NotPanics(t, func() {
+			assert.Empty(t, w.Render(&item, ctx, &settings))
+		})
 	})
 
 	assert.Equal(t, "magenta", w.DefaultColor())
@@ -1517,9 +1644,7 @@ func TestRateLimitWidget(t *testing.T) {
 
 	assert.Equal(t, "yellow", w.DefaultColor())
 	assert.True(t, w.SupportsRawValue())
-	pfx, ok := w.(Prefixer)
-	require.True(t, ok)
-	assert.Equal(t, "5h limit: ", pfx.DefaultPrefix())
+	assert.Equal(t, "5h limit: ", w.DefaultPrefix())
 }
 
 func TestRateLimitsWidget(t *testing.T) {
@@ -1567,9 +1692,7 @@ func TestRateLimitsWidget(t *testing.T) {
 
 	assert.Equal(t, "yellow", w.DefaultColor())
 	assert.False(t, w.SupportsRawValue())
-	pfx, ok := w.(Prefixer)
-	require.True(t, ok)
-	assert.Equal(t, "Limit ", pfx.DefaultPrefix())
+	assert.Equal(t, "Limit ", w.DefaultPrefix())
 }
 
 func TestEffortWidget(t *testing.T) {
@@ -1687,30 +1810,24 @@ func TestAddedDirsWidget(t *testing.T) {
 	assert.False(t, w.SupportsRawValue())
 }
 
-func TestStripANSI(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{"no ANSI", "hello", "hello"},
-		{"color code", "\033[32mgreen\033[0m", "green"},
-		{"bold", "\033[1mbold\033[0m", "bold"},
-		{"multiple codes", "\033[1;32mbold green\033[0m", "bold green"},
-		{"empty string", "", ""},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, stripANSI(tt.input))
-		})
-	}
-}
-
 func TestDefaultConfigWidgetsRegistered(t *testing.T) {
 	for _, line := range config.DefaultSettings().Lines {
 		for _, item := range line {
 			assert.NotNilf(t, Get(item.Type), "default config references unregistered widget %q", item.Type)
 		}
+	}
+}
+
+// TestAllWidgetsNilDataSafe enforces the convention that every widget's Render
+// tolerates a nil Session (and nil GitCache) without panicking.
+func TestAllWidgetsNilDataSafe(t *testing.T) {
+	settings := config.DefaultSettings()
+	for _, typ := range Types() {
+		w := Get(typ)
+		t.Run(typ, func(t *testing.T) {
+			assert.NotPanics(t, func() {
+				_ = w.Render(&config.WidgetItem{}, RenderContext{Data: nil}, &settings)
+			})
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Aligns the data model, widgets, and rendering pipeline with the current [Claude Code status line spec](https://code.claude.com/docs/en/statusline), and tightens the rendering internals. No config schema change — existing `settings.json` (version 4) keeps working unchanged.

## Spec alignment

- **New widgets** `repo` (owner/name from `workspace.repo`) and `pr` (`#number` + review state from `pr.*`), matching the official fields.
- **Session-directory git**: git commands run in `workspace.current_dir` (resolved via `Session.WorkingDir()`: current_dir → cwd → project_dir) through an injectable `git.Repo{Dir}`, so widgets read the right repo when Claude Code launches the status line from elsewhere. Worktree detection uses `--absolute-git-dir` so it works regardless of the run directory.
- **Width via COLUMNS**: `terminal.Width` reads `COLUMNS` first, matching the v2.1.153+ contract (output is captured, fds aren't a tty), and avoids spawning `ps` on the common path.
- **Context-window fallbacks**: `context-length` and cache-hit handle `current_usage` being null right after `/compact` by falling back to `total_input_tokens`, so the value does not blank out mid-session.
- **`git-worktree`** prefers `workspace.git_worktree` / `worktree.name` from JSON before the git heuristic.
- **`install`** gained `--padding` and now overrides only the flags the user explicitly set, so re-installing never silently drops a `statusLine` setting.

## Rendering / cleanup

- **Display-column width**: `VisibleWidth` / `Truncate` count wide (CJK, emoji) runes as 2 and combining marks as 0 (via `go-runewidth`); `StripANSI` / `ScanEscape` also handle OSC 8 hyperlinks. Truncation and flex layout no longer miscount multibyte output.
- **Multiple flex separators**: a row with N flex separators splits into N+1 groups and distributes free width evenly, enabling left/center/right layouts.
- **Custom commands** receive the exact stdin Claude Code sent (`RawInput`), so they see the full official schema including fields ccstatus does not model.
- `noAffix` replaces the optional `Prefixer` interface so every widget satisfies one `Widget` interface without boilerplate.
- `validate` now reports unknown types, missing/duplicate ids, and invalid colors, and exits non-zero — usable as a CI gate.
- The `jsonl` transcript reader raises its scanner cap to 1 MiB so a large first record does not silently yield no timestamp.

## Review fixes

- `dump` now builds the same `RenderContext` as the main path (`Git` + `RawInput`), so git widgets render in dump mode again (was regressing to blank).
- Removed the unused exported `Register` (no caller; a single static binary has no external widget registration).

## Testing

`go build`, `go vet`, `golangci-lint run` (0 issues), and `go test ./...` all pass. New tests cover the cmd layer (`validate`, `main`), the `git.Repo` provider, and the new widgets.
