### PR TITLE
ci: push homebrew formula via the shared app token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,15 @@ jobs:
           git tag ${{ inputs.version }}
           git push origin ${{ inputs.version }}
 
+      - name: Mint homebrew-tap token
+        id: tap-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.MOOND4RK_CI_RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.MOOND4RK_CI_RELEASE_APP_PRIVATE_KEY }}
+          owner: moonD4rk
+          repositories: homebrew-tap
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:
@@ -46,4 +55,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ inputs.version }}
-          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.MOOND4RK_HOMEBREW_TAP_GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ steps.tap-token.outputs.token }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -58,8 +58,8 @@ brews:
       branch: main
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     commit_author:
-      name: "github-actions[bot]"
-      email: "github-actions[bot]@users.noreply.github.com"
+      name: "moond4rk-ci[bot]"
+      email: "299850723+moond4rk-ci[bot]@users.noreply.github.com"
     commit_msg_template: "brew formula update for {{ .ProjectName }} version {{ .Tag }}"
     install: |
       bin.install "ccstatus"


### PR DESCRIPTION
Replace the long-lived Homebrew PAT with a short-lived app token when pushing the formula to `homebrew-tap` — same simple, direct-on-main release, just no standing PAT.

- Mint a token scoped to `homebrew-tap` via `create-github-app-token` and hand it to GoReleaser as `HOMEBREW_TAP_GITHUB_TOKEN` (was `secrets.MOOND4RK_HOMEBREW_TAP_GITHUB_TOKEN`).
- Attribute the formula-bump commit to the app instead of `github-actions[bot]`.

The tag push and GitHub Release still use the default `GITHUB_TOKEN`. Uses the shared release app (`vars.MOOND4RK_CI_RELEASE_APP_CLIENT_ID` + `secrets.MOOND4RK_CI_RELEASE_APP_PRIVATE_KEY`, added to this repo); the app is already installed on `homebrew-tap`.